### PR TITLE
fix: checkFieldGeneratedNullable

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -2709,7 +2709,7 @@ func (s *session) mysqlCheckField(t *TableInfo, field *ast.ColumnDef) {
 	if types.IsTypeBlob(field.Tp.Tp) {
 		s.AppendErrorNo(ER_USE_TEXT_OR_BLOB, field.Name.Name)
 	} else {
-		if !notNullFlag {
+		if !notNullFlag && !hasGenerated{
 			s.AppendErrorNo(ER_NOT_ALLOWED_NULLABLE, field.Name.Name, tableName)
 		}
 


### PR DESCRIPTION
修复：不允许null约束时，忽略对计算列Generated的nullable检查

**enable_nullable = false** 
`CREATE TABLE `t1`
(
  `id`            bigint(20)	unsigned NOT NULL AUTO_INCREMENT COMMENT '自增id',
  `operate_info`  json			not null COMMENT '日志记录',
  `type`          tinyint(10)	GENERATED ALWAYS AS (json_extract(`operate_info`, '$.type')) VIRTUAL COMMENT '操作类型',
  PRIMARY KEY (`id`)
) ENGINE = InnoDB
 COMMENT ='xxx';`