### PR TITLE
Feature DDL/DML分组功能

### DIFF
--- a/session/inception_result.go
+++ b/session/inception_result.go
@@ -569,12 +569,12 @@ func NewSplitSets() *SplitSets {
 	return t
 }
 
-func (s *SplitSets) Append(id int64, sql string, ddlflag int64, errmsg string) {
+func (s *SplitSets) Append(sql string, errmsg string) {
 	row := make([]types.Datum, s.rc.fieldCount)
 
-	row[0].SetInt64(id)
+	row[0].SetInt64(s.id)
 	row[1].SetString(sql)
-	row[2].SetInt64(ddlflag)
+	row[2].SetInt64(s.ddlflag)
 	if errmsg == "" {
 		row[3].SetNull()
 	} else {

--- a/session/inception_result.go
+++ b/session/inception_result.go
@@ -538,6 +538,14 @@ type SplitSets struct {
 	samples []types.Datum
 	rc      *recordSet
 	pk      ast.RecordSet
+
+	// 分组id,每当变化一次分组时,自动加1.默认值为1
+	id int64
+
+	sqlBuf *bytes.Buffer
+
+	ddlflag   int64
+	tableList map[string]bool
 }
 
 func NewSplitSets() *SplitSets {
@@ -575,6 +583,16 @@ func (s *SplitSets) Append(id int64, sql string, ddlflag int64, errmsg string) {
 
 	s.rc.data = append(s.rc.data, row)
 	s.rc.count++
+}
+
+// id累加
+func (s *SplitSets) Increment() {
+	s.id += 1
+}
+
+// CurrentId 当前ID
+func (s *SplitSets) CurrentId() int64 {
+	return s.id
 }
 
 func (s *SplitSets) Rows() []ast.RecordSet {

--- a/session/session.go
+++ b/session/session.go
@@ -225,6 +225,9 @@ type session struct {
 
 	// 统计信息
 	statistics *statisticsInfo
+
+	// DDL和DML分隔结果
+	splitSets *SplitSets
 }
 
 // DDLOwnerChecker returns s.ddlOwnerChecker.

--- a/session/session_inception_split_test.go
+++ b/session/session_inception_split_test.go
@@ -1,0 +1,212 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"fmt"
+	"strconv"
+	// "strings"
+	"testing"
+
+	"github.com/hanchuanchuan/goInception/config"
+	"github.com/hanchuanchuan/goInception/domain"
+	"github.com/hanchuanchuan/goInception/kv"
+	"github.com/hanchuanchuan/goInception/session"
+	"github.com/hanchuanchuan/goInception/store/mockstore"
+	"github.com/hanchuanchuan/goInception/store/mockstore/mocktikv"
+	"github.com/hanchuanchuan/goInception/util/testkit"
+	"github.com/hanchuanchuan/goInception/util/testleak"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testSessionSplitSuite{})
+
+func TestSplit(t *testing.T) {
+	TestingT(t)
+}
+
+type testSessionSplitSuite struct {
+	cluster   *mocktikv.Cluster
+	mvccStore mocktikv.MVCCStore
+	store     kv.Storage
+	dom       *domain.Domain
+	tk        *testkit.TestKit
+
+	version int
+	sqlMode string
+
+	rows [][]interface{}
+}
+
+func (s *testSessionSplitSuite) SetUpSuite(c *C) {
+
+	if testing.Short() {
+		c.Skip("skipping test; in TRAVIS mode")
+	}
+
+	testleak.BeforeTest()
+	s.cluster = mocktikv.NewCluster()
+	mocktikv.BootstrapWithSingleStore(s.cluster)
+	s.mvccStore = mocktikv.MustNewMVCCStore()
+	store, err := mockstore.NewMockTikvStore(
+		mockstore.WithCluster(s.cluster),
+		mockstore.WithMVCCStore(s.mvccStore),
+	)
+	c.Assert(err, IsNil)
+	s.store = store
+	session.SetSchemaLease(0)
+	session.SetStatsLease(0)
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+
+	// config.GetGlobalConfig().Inc.Lang = "zh-CN"
+	// session.SetLanguage("zh-CN")
+	config.GetGlobalConfig().Inc.Lang = "en-US"
+	config.GetGlobalConfig().Inc.EnableFingerprint = true
+	config.GetGlobalConfig().Inc.SqlSafeUpdates = 0
+	session.SetLanguage("en-US")
+
+	if s.tk == nil {
+		s.tk = testkit.NewTestKitWithInit(c, s.store)
+	}
+}
+
+func (s *testSessionSplitSuite) TearDownSuite(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test; in TRAVIS mode")
+	} else {
+		s.dom.Close()
+		s.store.Close()
+		testleak.AfterTest(c)()
+	}
+}
+
+func (s *testSessionSplitSuite) makeSQL(sql string) *testkit.Result {
+	a := `/*--user=test;--password=test;--host=127.0.0.1;--split=1;--port=3306;--enable-ignore-warnings;*/
+inception_magic_start;
+use test_inc;
+%s;
+inception_magic_commit;`
+	return s.tk.MustQueryInc(fmt.Sprintf(a, sql))
+}
+
+func (s *testSessionSplitSuite) TestBegin(c *C) {
+	sql := `/*--user=test;--password=test;--host=127.0.0.1;--split=1;--port=3306;--enable-ignore-warnings;*/
+use test_inc;
+create table t1(id int);`
+	// res := s.tk.MustQueryInc(sql)
+	s.tk.MustQueryInc(sql)
+
+	c.Assert(int(s.tk.Se.AffectedRows()), Equals, 1)
+	// 没有开始语法,无法返回split格式结果
+	// row := res.Rows()[s.tk.Se.AffectedRows()-1]
+	// c.Assert(row[3], Equals, "Must end with commit.")
+}
+
+func (s *testSessionSplitSuite) TestEnd(c *C) {
+	sql := `/*--user=test;--password=test;--host=127.0.0.1;--split=1;--port=3306;--enable-ignore-warnings;*/
+inception_magic_start;
+use test_inc;
+create table t1(id int);`
+	res := s.tk.MustQueryInc(sql)
+
+	c.Assert(int(s.tk.Se.AffectedRows()), Equals, 2)
+	row := res.Rows()[s.tk.Se.AffectedRows()-1]
+	c.Assert(row[3], Equals, "Must end with commit.")
+}
+
+func (s *testSessionSplitSuite) TestWrongStmt(c *C) {
+	sql := `/*--user=test;--password=test;--host=127.0.0.1;--split=1;--port=3306;--enable-ignore-warnings;*/
+inception_magic_start;
+123;
+inception_magic_commit;`
+	res := s.tk.MustQueryInc(sql)
+
+	c.Assert(int(s.tk.Se.AffectedRows()), Equals, 1)
+	row := res.Rows()[s.tk.Se.AffectedRows()-1]
+	c.Assert(row[3], Equals, "line 1 column 3 near \"\" (total length 3)")
+}
+
+func (s *testSessionSplitSuite) TestInsert(c *C) {
+
+	s.testRows(c, "insert into t1 values(1);", 1)
+}
+
+func (s *testSessionSplitSuite) TestUpdate(c *C) {
+
+	s.testRows(c, `update t1 set c1=1 where a=1;`, 1)
+}
+
+func (s *testSessionSplitSuite) TestDelete(c *C) {
+
+	s.testRows(c, `delete from t1 where id=1;`, 1)
+
+}
+
+func (s *testSessionSplitSuite) TestAlterTable(c *C) {
+
+	s.testRows(c, `alter table t1 add column c1 int;`, 1)
+
+}
+
+func (s *testSessionSplitSuite) TestMoreSql(c *C) {
+
+	s.testRows(c, `
+drop table if exists t1;
+create table t1 like test.t1;
+alter table t2 add column c1 int;
+insert into t3(c1) values(1);
+insert into t1(c1) values(1);
+truncate table t1;
+truncate table t2;
+
+truncate table t3;
+
+desc t1;
+insert into t3(c1) values(1);
+insert into t1(c1) values(1);
+
+alter table t1 add column c1 int;
+drop table if exists table1;drop table if exists table2;
+create table table1(id1 int primary key,c1 int);
+create table table2(id2 int primary key,c2 int,c22 int);
+
+update table1 a1,table2 a2 set a1.c1=a2.c2 where a1.id1=a2.id2 and a1.c1=a2.c2 and a1.id1 in (1,2,3);
+alter table table1 add column c10 int;
+update table1 a1,table2 a2 set a2.c1=a2.c2 where a1.id1=a2.id2 and a1.c1=a2.c2 and a1.id1 in (1,2,3);
+alter table table2 add column c10 int;
+update table1 a1,table2 a2 set a2.c1=a2.c2 where a1.id1=a2.id2 and a1.c1=a2.c2 and a1.id1 in (1,2,3);`, 7)
+
+	flags := []int{1, 0, 1, 0, 1, 1, 0}
+	for i, row := range s.rows {
+		c.Assert(row[2], Equals, strconv.Itoa(flags[i]), Commentf("%v", row))
+	}
+
+}
+
+func (s *testSessionSplitSuite) testRows(c *C, sql string, count int) {
+	if s.tk == nil {
+		s.tk = testkit.NewTestKitWithInit(c, s.store)
+	}
+
+	res := s.makeSQL(sql)
+	c.Assert(len(res.Rows()), Equals, count, Commentf("%v", res.Rows()))
+	c.Assert(int(s.tk.Se.AffectedRows()), Equals, count, Commentf("%v", res.Rows()))
+
+	for _, row := range res.Rows() {
+		c.Assert(row[3], Equals, "<nil>", Commentf("%v", row))
+	}
+
+	s.rows = res.Rows()
+}

--- a/session/session_print.go
+++ b/session/session_print.go
@@ -31,7 +31,7 @@ func (s *session) printCommand(ctx context.Context, stmtNode ast.StmtNode,
 
 	switch node := stmtNode.(type) {
 	case *ast.UseStmt:
-		s.checkChangeDB(node)
+		s.checkChangeDB(node, currentSql)
 
 	case *ast.InsertStmt:
 		s.printInsert(node, currentSql)


### PR DESCRIPTION
实现将一段SQL语句按互不影响原则分组DDL和DML语句，即相同表的DDL及DML语句分开两个语句块执行。
* **用法：** 在调用goInception时，指定 `--split=1` 或 `--enable-split` 选项，指定后，其他选项(审核、执行、备份、打印语法树等)均不再生效。
* **拆分原因：** 兼容老版inception，实际情况下 **可以不分组** ，goInception记录有表结构快照，用以实现binlog解析。

**输出结构：**
* id: 序号列，表示当前行被分成第几个语句块，从1开始
* sql_statement: 表示可以在一起的所有SQL语句, 以分号分隔
* ddlflag: 第三个列表示的是当前被拆之后，可以一起执行的语句中，有没有alter/drop table语句，如果有则输出1，否则输出0，这主要是为了防止在Inception执行这两种语句时有可能带来危险，这样输出之后，可以为上层提供更友好的选择，可以做为一个提醒
* error_message: 错误信息，如果语法错误，则会写入该处，而正常时该值为NULL
