### PR TITLE
Update osc processlist

### DIFF
--- a/session/osc.go
+++ b/session/osc.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -615,9 +616,11 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 	}
 	s.sessionManager.AddOscProcess(p)
 
+	var wg sync.WaitGroup
+	wg.Add(2)
+
 	// 消息
 	reader := bufio.NewReader(stdout)
-
 	// 进度
 	reader2 := bufio.NewReader(stderr)
 
@@ -628,6 +631,7 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 		for {
 			line, err2 := reader.ReadString('\n')
 			if err2 != nil || io.EOF == err2 {
+				wg.Done()
 				break
 			}
 			buf.WriteString(line)
@@ -647,6 +651,8 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 	go f(reader)
 	go f(reader2)
 
+	wg.Wait()
+
 	//阻塞直到该命令执行完成，该命令必须是被Start方法开始执行的
 	err = cmd.Wait()
 	if err != nil {
@@ -655,6 +661,8 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 		log.Error(err)
 	}
 	if p.Percent < 100 || s.hasError() {
+		s.recordSets.MaxLevel = 2
+		r.ErrLevel = 2
 		r.StageStatus = StatusExecFail
 	} else {
 		r.StageStatus = StatusExecOK

--- a/session/osc.go
+++ b/session/osc.go
@@ -46,6 +46,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var (
+	oscConnID uint32
+)
+
 type ChanOscData struct {
 	out string
 	p   *util.OscProcessInfo
@@ -479,6 +483,7 @@ func (s *session) mysqlExecuteAlterTableGhost(r *Record) {
 	}
 
 	p := &util.OscProcessInfo{
+		ID:         uint64(atomic.AddUint32(&oscConnID, 1)),
 		ConnID:     s.sessionVars.ConnectionID,
 		Schema:     r.TableInfo.Schema,
 		Table:      r.TableInfo.Name,
@@ -598,6 +603,7 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 	}
 
 	p := &util.OscProcessInfo{
+		ID:         uint64(atomic.AddUint32(&oscConnID, 1)),
 		ConnID:     s.sessionVars.ConnectionID,
 		Schema:     r.TableInfo.Schema,
 		Table:      r.TableInfo.Name,

--- a/session/osc.go
+++ b/session/osc.go
@@ -479,6 +479,7 @@ func (s *session) mysqlExecuteAlterTableGhost(r *Record) {
 	}
 
 	p := &util.OscProcessInfo{
+		ConnID:     s.sessionVars.ConnectionID,
 		Schema:     r.TableInfo.Schema,
 		Table:      r.TableInfo.Name,
 		Command:    r.Sql,
@@ -490,11 +491,11 @@ func (s *session) mysqlExecuteAlterTableGhost(r *Record) {
 	}
 	s.sessionManager.AddOscProcess(p)
 
-	defer func() {
-		// 执行完成或中止后清理osc进程信息
-		pl := s.sessionManager.ShowOscProcessList()
-		delete(pl, p.Sqlsha1)
-	}()
+	// defer func() {
+	// 	// 执行完成或中止后清理osc进程信息
+	// 	pl := s.sessionManager.ShowOscProcessList()
+	// 	delete(pl, p.Sqlsha1)
+	// }()
 
 	done := false
 	buf := bytes.NewBufferString("")
@@ -597,6 +598,7 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 	}
 
 	p := &util.OscProcessInfo{
+		ConnID:     s.sessionVars.ConnectionID,
 		Schema:     r.TableInfo.Schema,
 		Table:      r.TableInfo.Name,
 		Command:    r.Sql,
@@ -659,8 +661,8 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 	}
 
 	// 执行完成或中止后清理osc进程信息
-	pl := s.sessionManager.ShowOscProcessList()
-	delete(pl, p.Sqlsha1)
+	// pl := s.sessionManager.ShowOscProcessList()
+	// delete(pl, p.Sqlsha1)
 
 	return true
 }

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6569,7 +6569,9 @@ func (s *session) addNewSplitNode() {
 func (s *session) cleanup() {
 	// 执行完成或中止后清理osc进程信息
 	pl := s.sessionManager.ShowOscProcessList()
-
+	if len(pl) == 0 {
+		return
+	}
 	oscList := []string{}
 	for _, pi := range pl {
 		if pi.ConnID == s.sessionVars.ConnectionID {

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6567,6 +6567,9 @@ func (s *session) addNewSplitNode() {
 
 // cleanup 清理变量,缓存,osc进程等
 func (s *session) cleanup() {
+	if s.sessionManager == nil {
+		return
+	}
 	// 执行完成或中止后清理osc进程信息
 	pl := s.sessionManager.ShowOscProcessList()
 	if len(pl) == 0 {

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -54,6 +54,10 @@ type SessionManager interface {
 
 // OscProcessInfo is a struct used for show osc processlist statement.
 type OscProcessInfo struct {
+	ID uint64
+	// 连接ID
+	ConnID uint64
+
 	Schema     string
 	Table      string
 	Command    string


### PR DESCRIPTION
* 优化osc的进程列表显示
现在如果一次执行多条osc语句时，都会在osc进程列表，直到所有语句执行完成后才会清除。
* 优化osc的进程列表有序，按添加顺序
* 修复pt-osc可能出现执行成功，但进度不到100%的问题