### PR TITLE
修复 alter table 命令没有其他选项时能正常通过的bug

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3098,6 +3098,9 @@ func (s *session) checkAlterTable(node *ast.AlterTableStmt, sql string) {
 	for i, alter := range node.Specs {
 		switch alter.Tp {
 		case ast.AlterTableOption:
+			if len(alter.Options) == 0 {
+				s.AppendErrorNo(ER_NOT_SUPPORTED_ALTER_OPTION)
+			}
 			s.checkTableOptions(alter.Options, node.Table.Name.String(), false)
 		case ast.AlterTableAddColumns:
 			s.checkAddColumn(table, alter)

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3099,7 +3099,7 @@ func (s *session) checkAlterTable(node *ast.AlterTableStmt, sql string) {
 		switch alter.Tp {
 		case ast.AlterTableOption:
 			if len(alter.Options) == 0 {
-				s.AppendErrorNo(ER_NOT_SUPPORTED_ALTER_OPTION)
+				s.AppendErrorNo(ER_NOT_SUPPORTED_YET)
 			}
 			s.checkTableOptions(alter.Options, node.Table.Name.String(), false)
 		case ast.AlterTableAddColumns:

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2211,5 +2211,5 @@ func (s *testSessionIncSuite) TestAlterNoOption(c *C) {
 	
 	sql := `alter table t1;`
 	s.testErrorCode(c, sql,
-		session.NewErr(session.ER_NOT_SUPPORTED_ALTER_OPTION))
+		session.NewErr(session.ER_NOT_SUPPORTED_YET))
 }

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2202,3 +2202,14 @@ func (s *testSessionIncSuite) TestTimestampType(c *C) {
 		session.NewErr(session.ER_INVALID_DATA_TYPE, "a"))
 	config.GetGlobalConfig().Inc.EnableTimeStampType = true
 }
+
+func (s *testSessionIncSuite) TestAlterNoOption(c *C) {
+	saved := config.GetGlobalConfig().Inc
+	defer func() {
+		config.GetGlobalConfig().Inc = saved
+	}()
+	
+	sql := `alter table t1;`
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ER_NOT_SUPPORTED_ALTER_OPTION))
+}


### PR DESCRIPTION
修复 alter table t1; 命令没有其他选项时能正常通过的bug