### PR TITLE
新标识符必须为大写参数

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -303,6 +303,7 @@ type Inc struct {
 	// 将 float/double 转成 decimal, 默认为 false
 	CheckFloatDouble bool `toml:"check_float_double" json:"check_float_double"`
 	
+	CheckIdentifierUpper bool `toml:"check_identifier_upper" json:"check_identifier_upper"`
 
 	EnableAutoIncrementUnsigned bool `toml:"enable_autoincrement_unsigned" json:"enable_autoincrement_unsigned"`
 	// 允许blob,text,json列设置为NOT NULL
@@ -726,6 +727,7 @@ var defaultConf = Config{
 		CheckTimestampCount:   true,
 		EnableTimeStampType:   true,
 		CheckFloatDouble:      false,
+		CheckIdentifierUpper:  false,
 		SqlSafeUpdates:        -1,
 		SupportCharset:        "utf8,utf8mb4",
 		SupportEngine:         "innodb",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -261,6 +261,7 @@ check_table_comment = false
 check_column_comment = false
 
 check_float_double = false
+check_identifier_upper = false
 
 # 审核列类型变更
 check_column_type_change = true

--- a/session/errors.go
+++ b/session/errors.go
@@ -199,6 +199,7 @@ const (
 	ER_DATETIME_DEFAULT
 	ER_TOO_MUCH_AUTO_DATETIME_COLS
 	ErrFloatDoubleToDecimal
+	ErrIdentifierUpper
 	ER_ERROR_LAST
 )
 
@@ -362,6 +363,7 @@ var ErrorsDefault = map[ErrorCode]string{
 	ER_DATETIME_DEFAULT:            "Set default value for DATETIME column '%s'.",
 	ER_TOO_MUCH_AUTO_DATETIME_COLS: "Incorrect table definition; there can be only one DATETIME column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause",
 	ErrFloatDoubleToDecimal:        "Set column '%s' to DECIMAL type.",
+	ErrIdentifierUpper:             "Identifier '%s' must be capitalized.",
 }
 
 var ErrorsChinese = map[ErrorCode]string{
@@ -517,7 +519,8 @@ var ErrorsChinese = map[ErrorCode]string{
 	ErCantChangeColumnPosition:             "不允许改变列顺序(列'%s').",
 	ER_DATETIME_DEFAULT:                    "请设置 datetime 列 '%s' 的默认值.",
 	ER_TOO_MUCH_AUTO_DATETIME_COLS:         "表定义不正确,只能有一个 datetime 字段,在 DEFAULT 或 ON UPDATE指定CURRENT_TIMESTAMP.",
-	ErrFloatDoubleToDecimal:                "列 '%s' 建议设置为 decimal 类型",
+	ErrFloatDoubleToDecimal:                "列 '%s' 建议设置为 decimal 类型.",
+	ErrIdentifierUpper:                     "标识符 '%s' 必须大写.",
 }
 
 func GetErrorLevel(code ErrorCode) uint8 {
@@ -995,6 +998,8 @@ func (e ErrorCode) String() string {
 		return "er_cant_change_column_position"
 	case ErrFloatDoubleToDecimal:
 		return "er_float_double_to_decimal"
+	case ErrIdentifierUpper:
+		return "er_identifier_upper"
 	case ER_ERROR_LAST:
 		return "er_error_last"
 	}

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6358,7 +6358,7 @@ func (s *session) AppendErrorNo(number ErrorCode, values ...interface{}) {
 }
 
 func (s *session) checkKeyWords(name string) {
-	if s.Inc.CheckIdentifierUpper && name != strings.ToUpper(name){
+	if name != strings.ToUpper(name){
 		s.AppendErrorNo(ErrIdentifierUpper, name)
 	}
 	
@@ -6484,6 +6484,8 @@ func (s *session) checkInceptionVariables(number ErrorCode) bool {
 		return s.Inc.CheckDatetimeDefault
 	case ER_TOO_MUCH_AUTO_DATETIME_COLS:
 		return s.Inc.CheckDatetimeCount
+	case ErrIdentifierUpper:
+		return s.Inc.CheckIdentifierUpper
 	}
 
 	return true

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3837,7 +3837,7 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 		// 	}
 		// }
 		
-		if s.Inc.CheckIdentifierUpper && name != strings.ToUpper(name){
+		if name != strings.ToUpper(name){
 			s.AppendErrorNo(ErrIdentifierUpper, name)
 		}
 		

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3836,6 +3836,11 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 		// 		break
 		// 	}
 		// }
+		
+		if s.Inc.CheckIdentifierUpper && name != strings.ToUpper(name){
+			s.AppendErrorNo(ErrIdentifierUpper, name)
+		}
+		
 		if isIncorrectName(name) {
 			s.AppendErrorNo(ER_WRONG_NAME_FOR_INDEX, name, table.Name)
 		} else {
@@ -3856,12 +3861,12 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 		s.AppendErrorNo(ER_FOREIGN_KEY, table.Name)
 
 	case ast.ConstraintUniq:
-		if !strings.HasPrefix(name, "uniq_") {
+		if !strings.HasPrefix(strings.ToLower(name), "uniq_") {
 			s.AppendErrorNo(ER_INDEX_NAME_UNIQ_PREFIX, name, table.Name)
 		}
 
 	default:
-		if !strings.HasPrefix(name, "idx_") {
+		if  !strings.HasPrefix(strings.ToLower(name), "idx_"){
 			s.AppendErrorNo(ER_INDEX_NAME_IDX_PREFIX, name, table.Name)
 		}
 	}
@@ -6353,6 +6358,10 @@ func (s *session) AppendErrorNo(number ErrorCode, values ...interface{}) {
 }
 
 func (s *session) checkKeyWords(name string) {
+	if s.Inc.CheckIdentifierUpper && name != strings.ToUpper(name){
+		s.AppendErrorNo(ErrIdentifierUpper, name)
+	}
+	
 	if !regIdentified.MatchString(name) {
 		s.AppendErrorNo(ER_INVALID_IDENT, name)
 	} else if _, ok := Keywords[strings.ToUpper(name)]; ok {

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2238,3 +2238,19 @@ func (s *testSessionIncSuite) TestFloatDouble(c *C) {
 		session.NewErr(session.ErrFloatDoubleToDecimal, "c2"))
 	config.GetGlobalConfig().Inc.CheckFloatDouble = false
 }
+
+func (s *testSessionIncSuite) TestIdentifierUpper(c *C) {
+	saved := config.GetGlobalConfig().Inc
+	defer func() {
+		config.GetGlobalConfig().Inc = saved
+	}()
+	
+	config.GetGlobalConfig().Inc.CheckIdentifierUpper = true
+	sql := `drop table if exists hello;create table HELLO(ID int,C1 float, C2 double,key IDX_C1(C1),UNIQUE INDEX uniq_A(C2));`
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrIdentifierUpper, "uniq_A"),
+		)
+	
+	config.GetGlobalConfig().Inc.CheckIdentifierUpper = false
+}
+


### PR DESCRIPTION
新增 check_identifier_upper 参数，用于打开表名、列名、索引名大写需求