### PR TITLE
update: 订正两处错误的索引审核信息

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3830,7 +3830,7 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 	if tp == ast.ConstraintPrimaryKey {
 
 		if s.Inc.MaxPrimaryKeyParts > 0 && len(keys) > int(s.Inc.MaxPrimaryKeyParts) {
-			s.AppendErrorNo(ER_TOO_MANY_KEY_PARTS, table.Schema, table.Name, s.Inc.MaxPrimaryKeyParts)
+			s.AppendErrorNo(ER_PK_TOO_MANY_PARTS, table.Schema, table.Name, s.Inc.MaxPrimaryKeyParts)
 		}
 
 		s.checkDuplicateColumnName(keys)
@@ -3888,7 +3888,7 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 	}
 
 	if s.Inc.MaxKeyParts > 0 && len(keys) > int(s.Inc.MaxKeyParts) {
-		s.AppendErrorNo(ER_TOO_MANY_KEY_PARTS, table.Name, s.Inc.MaxKeyParts)
+		s.AppendErrorNo(ER_TOO_MANY_KEY_PARTS, name, table.Name, s.Inc.MaxKeyParts)
 	}
 
 }


### PR DESCRIPTION
修复两处异常
- ER_PK_TOO_MANY_PARTS审核信息错误写成ER_TOO_MANY_KEY_PARTS
- ER_TOO_MANY_KEY_PARTS审核信息少了索引名称