### PR TITLE
Feature tls connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.2.0
 
 replace vitess.io/vitess => github.com/vitessio/vitess v3.0.0-rc.3+incompatible
 
+replace github.com/go-sql-driver/mysql => github.com/go-sql-driver/mysql v1.4.1-0.20191022112324-6ea7374bc1b0
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/CorgiMan/json2 v0.0.0-20150213135156-e72957aba209
@@ -32,7 +34,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
-	github.com/etcd-io/gofail v0.0.0-20180808172546-51ce9a71510a // indirect
+	github.com/etcd-io/gofail v0.0.0-20180808172546-51ce9a71510a
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/github/gh-ost v1.0.48
 	github.com/go-sql-driver/mysql v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-sql-driver/mysql v1.4.1-0.20191022112324-6ea7374bc1b0 h1:VyNFVOiSqseRQ0S57xuC3at65pCTieqT4scZOpGwF24=
+github.com/go-sql-driver/mysql v1.4.1-0.20191022112324-6ea7374bc1b0/go.mod h1:XIaZU7xtUgusUqDPXOOPcmC5Dyyw3F1pbh54fHzaehk=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=

--- a/session/common.go
+++ b/session/common.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 
@@ -464,4 +465,9 @@ func findColumnWithList(c *ast.ColumnNameExpr, tables []*TableInfo) *FieldInfo {
 		}
 	}
 	return nil
+}
+
+func Exist(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil || os.IsExist(err)
 }

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -134,7 +134,7 @@ type sourceOptions struct {
 	// 连接的数据库,默认为mysql
 	db string
 
-	tls     bool   // 连接加密
+	ssl     string // 连接加密
 	sslCA   string // 证书颁发机构（CA）证书
 	sslCert string // 客户端公共密钥证书
 	sslKey  string // 客户端私钥文件
@@ -2423,7 +2423,7 @@ func (s *session) parseOptions(sql string) {
 		db: viper.GetString("db"),
 
 		// 连接加密
-		tls:     viper.GetBool("tls"),
+		ssl:     viper.GetString("ssl"),
 		sslCA:   viper.GetString("sslCa"),
 		sslCert: viper.GetString("sslCert"),
 		sslKey:  viper.GetString("sslKey"),
@@ -2456,62 +2456,10 @@ func (s *session) parseOptions(sql string) {
 
 	var addr string
 	if s.opt.middlewareExtend == "" {
-		tlsValue := "false"
-		if s.opt.sslCA != "" {
-			var errMsg string
-			if !Exist(s.opt.sslCA) {
-				errMsg = fmt.Sprintf("file: %s cannot open!", s.opt.sslCA)
-			}
-			if !Exist(s.opt.sslCert) {
-				errMsg += fmt.Sprintf("file: %s cannot open!", s.opt.sslCA)
-			}
-			if !Exist(s.opt.sslKey) {
-				errMsg += fmt.Sprintf("file: %s cannot open!", s.opt.sslCA)
-			}
-
-			if errMsg != "" {
-				log.Errorf("con:%d %s", s.sessionVars.ConnectionID, errMsg)
-				s.AppendErrorMessage(fmt.Sprintf("con:%d %s", s.sessionVars.ConnectionID, errMsg))
-				return
-			}
-
-			tlsValue = fmt.Sprintf("%s_%d", s.opt.host, s.opt.port)
-			if len(tlsValue) > mysql.MaxDatabaseNameLength {
-				tlsValue = tlsValue[len(tlsValue)-mysql.MaxDatabaseNameLength:]
-			}
-			tlsValue = strings.Replace(tlsValue, "-", "_", -1)
-			tlsValue = strings.Replace(tlsValue, ".", "_", -1)
-
-			rootCertPool := x509.NewCertPool()
-			pem, err := ioutil.ReadFile(s.opt.sslCA)
-			if err != nil {
-				log.Errorf("con:%d %v", s.sessionVars.ConnectionID, err)
-				s.AppendErrorMessage(err.Error())
-				return
-			}
-			if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-				log.Errorf("con:%d Failed to append PEM.", s.sessionVars.ConnectionID)
-				s.AppendErrorMessage(fmt.Sprintf("con:%d Failed to append PEM.", s.sessionVars.ConnectionID))
-				return
-			}
-			clientCert := make([]tls.Certificate, 0, 1)
-			certs, err := tls.LoadX509KeyPair(s.opt.sslCert, s.opt.sslKey)
-			if err != nil {
-				log.Errorf("con:%d %v", s.sessionVars.ConnectionID, err)
-				s.AppendErrorMessage(err.Error())
-				return
-			}
-			clientCert = append(clientCert, certs)
-			mysqlDriver.RegisterTLSConfig(tlsValue, &tls.Config{
-				RootCAs:      rootCertPool,
-				Certificates: clientCert,
-			})
-		} else if s.opt.tls {
-			tlsValue = "skip-verify"
+		tlsValue, ok := s.getTLSConfig()
+		if !ok {
+			return
 		}
-
-		log.Info(tlsValue)
-		log.Infof("%#v", s.opt)
 		addr = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=%s&parseTime=True&loc=Local&maxAllowedPacket=%d&tls=%s",
 			s.opt.user, s.opt.password, s.opt.host, s.opt.port, s.opt.db,
 			s.Inc.DefaultCharset, s.Inc.MaxAllowedPacket, tlsValue)
@@ -2581,6 +2529,94 @@ func (s *session) parseOptions(sql string) {
 	}
 
 	s.setSqlSafeUpdates()
+}
+
+// getTLSConfig 获取tls设置
+// https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode
+func (s *session) getTLSConfig() (string, bool) {
+	tlsValue := "false"
+	s.opt.ssl = strings.ToLower(s.opt.ssl)
+	switch s.opt.ssl {
+	case "preferred", "true":
+		tlsValue = "true"
+	case "required":
+		tlsValue = "skip-verify"
+	case "verify_ca", "verify_identity":
+		var errMsg string
+		if s.opt.sslCA == "" {
+			errMsg = "required CA file in PEM format."
+		}
+		if s.opt.sslCert == "" {
+			errMsg += "required X509 cert in PEM format."
+		}
+		if s.opt.sslCert == "" {
+			errMsg += "required X509 key in PEM format."
+		}
+		if errMsg != "" {
+			log.Errorf("con:%d %s", s.sessionVars.ConnectionID, errMsg)
+			s.AppendErrorMessage(errMsg)
+			return "", false
+		}
+
+		if !Exist(s.opt.sslCA) {
+			errMsg = fmt.Sprintf("file: %s cannot open.", s.opt.sslCA)
+		}
+		if !Exist(s.opt.sslCert) {
+			errMsg += fmt.Sprintf("file: %s cannot open.", s.opt.sslCA)
+		}
+		if !Exist(s.opt.sslKey) {
+			errMsg += fmt.Sprintf("file: %s cannot open.", s.opt.sslCA)
+		}
+
+		if errMsg != "" {
+			log.Errorf("con:%d %s", s.sessionVars.ConnectionID, errMsg)
+			s.AppendErrorMessage(errMsg)
+			return "", false
+		}
+
+		tlsValue = fmt.Sprintf("%s_%d", s.opt.host, s.opt.port)
+		if len(tlsValue) > mysql.MaxDatabaseNameLength {
+			tlsValue = tlsValue[len(tlsValue)-mysql.MaxDatabaseNameLength:]
+		}
+		tlsValue = strings.Replace(tlsValue, "-", "_", -1)
+		tlsValue = strings.Replace(tlsValue, ".", "_", -1)
+
+		rootCertPool := x509.NewCertPool()
+		pem, err := ioutil.ReadFile(s.opt.sslCA)
+		if err != nil {
+			log.Errorf("con:%d %v", s.sessionVars.ConnectionID, err)
+			s.AppendErrorMessage(err.Error())
+			return "", false
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			log.Errorf("con:%d Failed to append PEM.", s.sessionVars.ConnectionID)
+			s.AppendErrorMessage("Failed to append PEM.")
+			return "", false
+		}
+
+		clientCert := make([]tls.Certificate, 0, 1)
+		certs, err := tls.LoadX509KeyPair(s.opt.sslCert, s.opt.sslKey)
+		if err != nil {
+			log.Errorf("con:%d %v", s.sessionVars.ConnectionID, err)
+			s.AppendErrorMessage(err.Error())
+			return "", false
+		}
+		clientCert = append(clientCert, certs)
+
+		mysqlDriver.RegisterTLSConfig(tlsValue, &tls.Config{
+			// ServerName:         s.opt.host,
+			RootCAs:            rootCertPool,
+			Certificates:       clientCert,
+			InsecureSkipVerify: s.opt.ssl == "verify_ca",
+		})
+
+	default:
+		tlsValue = "false"
+	}
+
+	// log.Info(tlsValue)
+	// log.Infof("%#v", s.opt)
+	return tlsValue, true
 }
 
 func (s *session) parseIncLevel() {


### PR DESCRIPTION
添加mysql安全连接支持

 `ssl` 参数支持以下方式连接（[官网ssl-mode参数说明](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode)）：
- PREFERRED
- REQUIRED
- VERIFY_CA
- VERIFY_IDENTITY

使用CA证书认证时可指定以下参数：
- --ssl-ca
- --ssl-cert
- --ssl-key