### PR TITLE
修复表内有text,json等[]byte类型字段时最小化生成回滚语句panic的问题

### DIFF
--- a/session/parser.go
+++ b/session/parser.go
@@ -654,8 +654,16 @@ func (s *session) generateUpdateSql(t *TableInfo, e *replication.RowsEvent,
 				// 	continue
 				// }
 				if minimalMode {
+					equal := false
+
+					switch d.(type) {
+					case []byte:
+						equal = reflect.DeepEqual(d, e.Rows[i+1][j])
+					default:
+						equal = d == e.Rows[i+1][j]
+					}
 					// 最小化模式下,列如果相等则省略
-					if d != e.Rows[i+1][j] {
+					if !equal {
 						if t.Fields[j].IsUnsigned() {
 							d = processValue(d, GetDataTypeBase(t.Fields[j].Type))
 						}


### PR DESCRIPTION
修复表内有text,json等[]byte类型字段时最小化生成回滚语句panic的问题