### PR TITLE
fix: 修复非空字段insert审核时对自增列的处理 (#113)

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4993,7 +4993,7 @@ func (s *session) checkInsert(node *ast.InsertStmt, sql string) {
 		for _, field := range table.Fields {
 			if strings.EqualFold(field.Field, c.Name.O) && !field.IsDeleted {
 				found = true
-				if field.Null == "NO" {
+				if field.Null == "NO" && !strings.Contains(field.Extra, "auto_increment") {
 					columnsCannotNull[c.Name.L] = true
 				}
 				break


### PR DESCRIPTION
跳过自增列的审核, 自增列允许写入NULL值