### PR TITLE
Patch table index prefix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -329,8 +329,14 @@ type Inc struct {
 	GeneralLog bool `toml:"general_log" json:"general_log"`
 	// 使用十六进制表示法转储二进制列
 	// 受影响的数据类型为BINARY，VARBINARY，BLOB类型
-	HexBlob bool   `toml:"hex_blob" json:"hex_blob"`
-	Lang    string `toml:"lang" json:"lang"`
+	HexBlob bool `toml:"hex_blob" json:"hex_blob"`
+
+	// 表名/索引名前缀，为空时不作限制
+	IndexPrefix     string `toml:"index_prefix" json:"index_prefix"`
+	UniqIndexPrefix string `toml:"uniq_index_prefix" json:"uniq_index_prefix"`
+	TablePrefix     string `toml:"table_prefix" json:"table_prefix"`
+
+	Lang string `toml:"lang" json:"lang"`
 	// 连接服务器允许的最大包大小,以字节为单位 默认值为4194304(即4MB)
 	MaxAllowedPacket uint `toml:"max_allowed_packet" json:"max_allowed_packet"`
 	MaxCharLength    uint `toml:"max_char_length" json:"max_char_length"`
@@ -588,7 +594,6 @@ type IncLevel struct {
 	ER_AUTO_INCR_ID_WARNING         int8 `toml:"er_auto_incr_id_warning"`
 	ER_AUTOINC_UNSIGNED             int8 `toml:"er_autoinc_unsigned"`
 	ER_BLOB_CANT_HAVE_DEFAULT       int8 `toml:"er_blob_cant_have_default"`
-	ErCantChangeColumn              int8 `toml:"er_cant_change_column"`
 	ER_CANT_SET_CHARSET             int8 `toml:"er_cant_set_charset"`
 	ER_CANT_SET_COLLATION           int8 `toml:"er_cant_set_collation"`
 	ER_CANT_SET_ENGINE              int8 `toml:"er_cant_set_engine"`
@@ -619,6 +624,7 @@ type IncLevel struct {
 	ER_TABLE_CHARSET_MUST_UTF8      int8 `toml:"er_table_charset_must_utf8"`
 	ER_TABLE_MUST_HAVE_COMMENT      int8 `toml:"er_table_must_have_comment"`
 	ER_TABLE_MUST_HAVE_PK           int8 `toml:"er_table_must_have_pk"`
+	ER_TABLE_PREFIX                 int8 `toml:"er_table_prefix"`
 	ER_TEXT_NOT_NULLABLE_ERROR      int8 `toml:"er_text_not_nullable_error"`
 	ER_TIMESTAMP_DEFAULT            int8 `toml:"er_timestamp_default"`
 	ER_TOO_MANY_KEY_PARTS           int8 `toml:"er_too_many_key_parts"`
@@ -632,11 +638,12 @@ type IncLevel struct {
 	ER_WITH_INSERT_FIELD            int8 `toml:"er_with_insert_field"`
 	ER_WITH_LIMIT_CONDITION         int8 `toml:"er_with_limit_condition"`
 	ER_WITH_ORDERBY_CONDITION       int8 `toml:"er_with_orderby_condition"`
-	ErrWrongAndExpr                 int8 `toml:"er_wrong_and_expr"`
+	ErCantChangeColumn              int8 `toml:"er_cant_change_column"`
 	ErCantChangeColumnPosition      int8 `toml:"er_cant_change_column_position"`
 	ErJsonTypeSupport               int8 `toml:"er_json_type_support"`
-	ErrJoinNoOnCondition            int8 `toml:"er_join_no_on_condition"`
 	ErrImplicitTypeConversion       int8 `toml:"er_implicit_type_conversion"`
+	ErrJoinNoOnCondition            int8 `toml:"er_join_no_on_condition"`
+	ErrWrongAndExpr                 int8 `toml:"er_wrong_and_expr"`
 }
 
 var defaultConf = Config{
@@ -745,6 +752,10 @@ var defaultConf = Config{
 		// 为配置方便,在config节点也添加相同参数
 		SkipGrantTable: true,
 		// Version:            &mysql.TiDBReleaseVersion,
+
+		IndexPrefix:     "idx_",  // 默认不检查,由CheckIndexPrefix控制
+		UniqIndexPrefix: "uniq_", // 默认不检查,由CheckIndexPrefix控制
+		TablePrefix:     "",      // 默认不检查表前缀
 	},
 	Osc: Osc{
 		OscPrintNone:               false,
@@ -791,7 +802,6 @@ var defaultConf = Config{
 		ER_AUTO_INCR_ID_WARNING:         1,
 		ER_AUTOINC_UNSIGNED:             1,
 		ER_BLOB_CANT_HAVE_DEFAULT:       1,
-		ErCantChangeColumn:              1,
 		ER_CANT_SET_CHARSET:             1,
 		ER_CANT_SET_COLLATION:           1,
 		ER_CANT_SET_ENGINE:              1,
@@ -811,7 +821,6 @@ var defaultConf = Config{
 		ER_INVALID_IDENT:                1,
 		ER_MUST_HAVE_COLUMNS:            1,
 		ER_NO_WHERE_CONDITION:           1,
-		ErrJoinNoOnCondition:            1,
 		ER_NOT_ALLOWED_NULLABLE:         1,
 		ER_ORDERY_BY_RAND:               1,
 		ER_PARTITION_NOT_ALLOWED:        1,
@@ -823,6 +832,7 @@ var defaultConf = Config{
 		ER_TABLE_CHARSET_MUST_UTF8:      1,
 		ER_TABLE_MUST_HAVE_COMMENT:      1,
 		ER_TABLE_MUST_HAVE_PK:           1,
+		ER_TABLE_PREFIX:                 1,
 		ER_TEXT_NOT_NULLABLE_ERROR:      1,
 		ER_TIMESTAMP_DEFAULT:            1,
 		ER_TOO_MANY_KEY_PARTS:           1,
@@ -836,10 +846,12 @@ var defaultConf = Config{
 		ER_WITH_INSERT_FIELD:            1,
 		ER_WITH_LIMIT_CONDITION:         1,
 		ER_WITH_ORDERBY_CONDITION:       1,
-		ErrWrongAndExpr:                 1,
+		ErCantChangeColumn:              1,
 		ErCantChangeColumnPosition:      1,
 		ErJsonTypeSupport:               2,
 		ErrImplicitTypeConversion:       1,
+		ErrJoinNoOnCondition:            1,
+		ErrWrongAndExpr:                 1,
 	},
 }
 

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -54,6 +54,11 @@ check_column_comment = false
 # 审核列类型变更
 check_column_type_change = true
 
+# 表名/索引名前缀
+index_prefix = "idx_"
+uniq_index_prefix = "uniq_"
+table_prefix = ""
+
 # explain判断受影响行数时使用的规则, 默认值"first"
 # 可选值: "first", "max"
 #      "first":    使用第一行的explain结果作为受影响行数

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -202,6 +202,7 @@ er_table_charset_must_null = 1
 er_table_charset_must_utf8 = 1
 er_table_must_have_comment = 1
 er_table_must_have_pk = 1
+er_table_prefix = 1
 er_text_not_nullable_error = 1
 er_timestamp_default = 1
 er_too_many_key_parts = 1

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -269,6 +269,11 @@ check_identifier_upper = false
 # 审核列类型变更
 check_column_type_change = true
 
+# 表名/索引名前缀
+index_prefix = "idx_"
+uniq_index_prefix = "uniq_"
+table_prefix = ""
+
 # explain判断受影响行数时使用的规则, 默认值"first"
 # 可选值: "first", "max"
 #      "first":    使用第一行的explain结果作为受影响行数

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -334,6 +334,7 @@ er_table_charset_must_null = 1
 er_table_charset_must_utf8 = 1
 er_table_must_have_comment = 1
 er_table_must_have_pk = 1
+er_table_prefix = 1
 er_text_not_nullable_error = 1
 er_timestamp_default = 1
 er_too_many_key_parts = 1

--- a/session/errors.go
+++ b/session/errors.go
@@ -95,6 +95,7 @@ const (
 	ER_TOO_LONG_INDEX_COMMENT
 	ER_DUP_INDEX
 	ER_TEMP_TABLE_TMP_PREFIX
+	ER_TABLE_PREFIX
 	ER_TABLE_CHARSET_MUST_UTF8
 	ER_TABLE_CHARSET_MUST_NULL
 	ER_TABLE_MUST_HAVE_COMMENT
@@ -263,6 +264,7 @@ var ErrorsDefault = map[ErrorCode]string{
 	ER_TOO_LONG_INDEX_COMMENT:              "Comment for index '%s' is too long (max = %lu).",
 	ER_DUP_INDEX:                           "Duplicate index '%s' defined on the table '%s.%s'.",
 	ER_TEMP_TABLE_TMP_PREFIX:               "Set 'tmp' prefix for temporary table.",
+	ER_TABLE_PREFIX:                        "Need set '%s' prefix for table.",
 	ER_TABLE_CHARSET_MUST_UTF8:             "Set charset to one of '%s' for table '%s'.",
 	ER_TABLE_CHARSET_MUST_NULL:             "Not allowed set charset for table '%s'.",
 	ErrTableCollationNotSupport:            "Not allowed set collation for table '%s'.",
@@ -432,6 +434,7 @@ var ErrorsChinese = map[ErrorCode]string{
 	ER_TOO_LONG_INDEX_COMMENT:              "索引 '%s' 注释过长(max = %lu).",
 	ER_DUP_INDEX:                           "索引 '%s' 定义重复(表'%s.%s').",
 	ER_TEMP_TABLE_TMP_PREFIX:               "临时表需要指定'tmp'前缀",
+	ER_TABLE_PREFIX:                        "表名需要指定'%s'前缀",
 	ER_TABLE_CHARSET_MUST_UTF8:             "允许的字符集为: '%s'(表'%s').",
 	ER_TABLE_CHARSET_MUST_NULL:             "表 '%s' 禁止设置字符集!",
 	ErrTableCollationNotSupport:            "表 '%s' 禁止设置排序规则!",
@@ -468,8 +471,8 @@ var ErrorsChinese = map[ErrorCode]string{
 	ER_END_WITH_COMMIT:                     "Must end with commit.",
 	ER_DB_NOT_EXISTED_ERROR:                "选择的数据库 '%s' 不存在.",
 	ER_TABLE_EXISTS_ERROR:                  "表 '%s' 已存在.",
-	ER_INDEX_NAME_IDX_PREFIX:               "索引 '%s' 需要以'idx_'为前缀(表'%s').",
-	ER_INDEX_NAME_UNIQ_PREFIX:              "索引 '%s' 需要以'uniq_'为前缀(表'%s').",
+	ER_INDEX_NAME_IDX_PREFIX:               "索引 '%s' 需要指定'%s'前缀(表'%s').",
+	ER_INDEX_NAME_UNIQ_PREFIX:              "唯一索引 '%s' 需要指定'%s'前缀(表'%s').",
 	ER_AUTOINC_UNSIGNED:                    "自增列建议设置无符号标志unsigned(表'%s').",
 	ER_VARCHAR_TO_TEXT_LEN:                 "列 '%s' 建议设置为text类型.",
 	ER_CHAR_TO_VARCHAR_LEN:                 "列 '%s' 建议设置为varchar类型.",
@@ -559,6 +562,8 @@ func GetErrorLevel(code ErrorCode) uint8 {
 		ER_INC_INIT_ERR,
 		ER_INDEX_NAME_IDX_PREFIX,
 		ER_INDEX_NAME_UNIQ_PREFIX,
+		ER_TEMP_TABLE_TMP_PREFIX,
+		ER_TABLE_PREFIX,
 		ER_INSERT_TOO_MUCH_ROWS,
 		ER_INVALID_DATA_TYPE,
 		ER_INVALID_IDENT,
@@ -614,7 +619,6 @@ func GetErrorLevel(code ErrorCode) uint8 {
 		ER_INVALID_DEFAULT,
 		ER_NOT_SUPPORTED_KEY_TYPE,
 		ER_DUP_INDEX,
-		ER_TEMP_TABLE_TMP_PREFIX,
 		ER_TOO_LONG_KEY,
 		ER_MULTIPLE_PRI_KEY,
 		ER_DUP_KEYNAME,
@@ -816,6 +820,8 @@ func (e ErrorCode) String() string {
 		return "er_dup_index"
 	case ER_TEMP_TABLE_TMP_PREFIX:
 		return "er_temp_table_tmp_prefix"
+	case ER_TABLE_PREFIX:
+		return "er_table_prefix"
 	case ER_TABLE_CHARSET_MUST_UTF8:
 		return "er_table_charset_must_utf8"
 	case ER_TABLE_CHARSET_MUST_NULL:

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3365,6 +3365,10 @@ func (s *session) checkCreateTable(node *ast.CreateTableStmt, sql string) {
 			}
 		} else {
 
+			if !strings.HasPrefix(node.Table.Name.L, s.Inc.TablePrefix) {
+				s.AppendErrorNo(ER_TABLE_PREFIX, s.Inc.TablePrefix)
+			}
+
 			// 校验列是否重复指定
 			checkDup := map[string]bool{}
 			for _, c := range node.Cols {
@@ -4700,8 +4704,8 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 		s.AppendErrorNo(ER_FOREIGN_KEY, table.Name)
 
 	case ast.ConstraintUniq:
-		if !strings.HasPrefix(strings.ToLower(name), "uniq_") {
-			s.AppendErrorNo(ER_INDEX_NAME_UNIQ_PREFIX, name, table.Name)
+		if !strings.HasPrefix(strings.ToLower(name), s.Inc.UniqIndexPrefix) {
+			s.AppendErrorNo(ER_INDEX_NAME_UNIQ_PREFIX, name, s.Inc.UniqIndexPrefix, table.Name)
 		}
 
 	case ast.ConstraintSpatial:
@@ -4710,8 +4714,8 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 		}
 
 	default:
-		if !strings.HasPrefix(strings.ToLower(name), "idx_") {
-			s.AppendErrorNo(ER_INDEX_NAME_IDX_PREFIX, name, table.Name)
+		if !strings.HasPrefix(strings.ToLower(name), s.Inc.IndexPrefix) {
+			s.AppendErrorNo(ER_INDEX_NAME_IDX_PREFIX, name, s.Inc.IndexPrefix, table.Name)
 		}
 	}
 

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -685,14 +685,22 @@ primary key(id)) comment 'test';`
 	sql = "create table test_error_code_3(a text, unique (a(3073)));"
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ER_WRONG_NAME_FOR_INDEX, "NULL", "test_error_code_3"),
-		session.NewErr(session.ER_INDEX_NAME_UNIQ_PREFIX, "", "test_error_code_3"),
+		session.NewErr(session.ER_INDEX_NAME_UNIQ_PREFIX, "",
+			config.GetGlobalConfig().Inc.UniqIndexPrefix, "test_error_code_3"),
 		session.NewErr(session.ER_TOO_LONG_KEY, "", indexMaxLength))
 
 	sql = "create table test_error_code_3(a text, key (a(3073)));"
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ER_WRONG_NAME_FOR_INDEX, "NULL", "test_error_code_3"),
-		session.NewErr(session.ER_INDEX_NAME_IDX_PREFIX, "", "test_error_code_3"),
+		session.NewErr(session.ER_INDEX_NAME_IDX_PREFIX, "",
+			config.GetGlobalConfig().Inc.IndexPrefix, "test_error_code_3"),
 		session.NewErr(session.ER_TOO_LONG_KEY, "", indexMaxLength))
+
+	config.GetGlobalConfig().Inc.TablePrefix = "t_"
+	sql = "create table t1(id int primary key);"
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ER_TABLE_PREFIX,
+			config.GetGlobalConfig().Inc.TablePrefix))
 
 }
 


### PR DESCRIPTION
添加以下审核参数：

- `table_prefix` 表名前缀，默认为空，即不限制
- `index_prefix` 普通索引前缀，默认为 `idx_`
- `uniq_index_prefix` 唯一索引前缀，默认为 `uniq_`

**注意：两个索引前缀受开关 `check_index_prefix` 影响。**