### PR TITLE
add: show variables添加版本号信息

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,11 +16,14 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"strings"
+
 	// "fmt"
 	"io/ioutil"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/hanchuanchuan/goInception/mysql"
 	"github.com/hanchuanchuan/goInception/util/logutil"
 	"github.com/pingcap/errors"
 	tracing "github.com/uber/jaeger-client-go/config"
@@ -379,6 +382,9 @@ type Inc struct {
 	SupportEngine string `toml:"support_engine" json:"support_engine"`
 	// 远端数据库等待超时时间，单位:秒
 	WaitTimeout int `toml:"wait_timeout" json:"wait_timeout"`
+
+	// 版本信息
+	Version string `toml:"version" json:"version"`
 }
 
 // Osc online schema change 工具参数配置
@@ -751,7 +757,9 @@ var defaultConf = Config{
 
 		// 为配置方便,在config节点也添加相同参数
 		SkipGrantTable: true,
-		// Version:            &mysql.TiDBReleaseVersion,
+
+		// 默认参数不指定,避免test时失败
+		// Version:            mysql.TiDBReleaseVersion,
 
 		IndexPrefix:     "idx_",  // 默认不检查,由CheckIndexPrefix控制
 		UniqIndexPrefix: "uniq_", // 默认不检查,由CheckIndexPrefix控制
@@ -867,6 +875,8 @@ func NewConfig() *Config {
 // It should store configuration from command line and configuration file.
 // Other parts of the system can read the global configuration use this function.
 func GetGlobalConfig() *Config {
+	// 自动设置版本号
+	globalConf.Inc.Version = strings.TrimRight(mysql.TiDBReleaseVersion, "-dirty")
 	return &globalConf
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,8 +17,10 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/hanchuanchuan/goInception/mysql"
 	. "github.com/pingcap/check"
 )
 
@@ -60,6 +62,8 @@ commit-timeout="41s"`)
 
 	configFile = path.Join(path.Dir(localFile), "config.toml.example")
 	c.Assert(conf.Load(configFile), IsNil)
+
+	conf.Inc.Version = strings.TrimRight(mysql.TiDBReleaseVersion, "-dirty")
 
 	// fmt.Println(conf)
 	// fmt.Println(GetGlobalConfig())

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6036,6 +6036,10 @@ func (s *session) executeInceptionSet(node *ast.InceptionSetStmt, sql string) ([
 				return nil, err
 			}
 		default:
+			if prefix == "version" {
+				return nil, errors.New("只读变量")
+			}
+
 			err = s.setVariableValue(reflect.TypeOf(cnf.Inc), reflect.ValueOf(&cnf.Inc).Elem(), v.Name, value)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
可通过下列SQL获取goinception的版本号信息
```sql
inception show variables like 'version';
```

该变更为只读变量, 禁止手动设置值
误设置时会报错 `inception set version="123";`
```
ERROR 1105 (HY000): 只读变量
```