### PR TITLE
fix: 优化使用pt工具时注释导致alter子句解析失败的问题

### DIFF
--- a/session/osc.go
+++ b/session/osc.go
@@ -853,8 +853,8 @@ func (s *session) getAlterTablePostPart(sql string, isPtOSC bool) string {
 
 // getAlterPartSql 获取alter子句部分
 func (s *session) getAlterPartSql(sql string) (string, bool) {
-	sql = strings.Replace(sql, "\n", " ", -1)
-	sql = strings.Replace(sql, "\r", " ", -1)
+	// sql = strings.Replace(sql, "\n", " ", -1)
+	// sql = strings.Replace(sql, "\r", " ", -1)
 
 	charsetInfo, collation := s.sessionVars.GetCharsetInfo()
 	stmtNodes, _, err := s.parser.Parse(sql, charsetInfo, collation)
@@ -865,7 +865,14 @@ func (s *session) getAlterPartSql(sql string) (string, bool) {
 	var builder strings.Builder
 	var columns []string
 
+	if len(stmtNodes) == 0 {
+		s.AppendErrorMessage(fmt.Sprintf("未正确解析ALTER语句: %s", sql))
+		log.Error(fmt.Sprintf("未正确解析ALTER语句: %s", sql))
+		return "", false
+	}
+
 	for _, stmtNode := range stmtNodes {
+
 		switch node := stmtNode.(type) {
 		case *ast.AlterTableStmt:
 			for _, alter := range node.Specs {

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -1261,22 +1261,28 @@ func (s *testSessionIncExecSuite) TestAlterTablePtOSC(c *C) {
 	s.mustRunExec(c, sql)
 
 	// 删除后添加列
-	sql = "alter table t1 drop column c1;alter table t1 add column c1 varchar(20);"
+	sql = `# 这是一条注释
+		alter table t1 drop column c1;alter table t1 add column c1 varchar(20);`
 	s.testErrorCode(c, sql)
 
-	sql = "alter table t1 drop column c1,add column c1 varchar(20);"
+	sql = `/* 这是一条注释 */
+		alter table t1 drop column c1,add column c1 varchar(20);`
 	s.testErrorCode(c, sql)
 
 	sql = "alter table t1 drop column c1,add column c1 varchar(20) comment '123';"
 	s.testErrorCode(c, sql)
 
-	sql = "alter table t1 add column c2 varchar(20) comment '!@#$%^&*()_+[]{}\\|;:\",.<>/?';"
+	sql = `-- 这是一条注释
+	alter table t1 add column c2 varchar(20) comment '!@#$%^&*()_+[]{}\\|;:",.<>/?';`
 	s.testErrorCode(c, sql)
 
 	sql = "alter table t1 add column c3 varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";"
 	s.testErrorCode(c, sql)
 
 	sql = "alter table t1 add column `c4` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";"
+	s.testErrorCode(c, sql)
+
+	sql = "alter table t1 add column `c5` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";  -- 测试注释"
 	s.testErrorCode(c, sql)
 }
 
@@ -1299,16 +1305,19 @@ func (s *testSessionIncExecSuite) TestAlterTableGhost(c *C) {
 	s.mustRunExec(c, sql)
 
 	// 删除后添加列
-	sql = "alter table t1 drop column c1;alter table t1 add column c1 varchar(20);"
+	sql = `# 这是一条注释
+	alter table t1 drop column c1;alter table t1 add column c1 varchar(20);`
 	s.testErrorCode(c, sql)
 
-	sql = "alter table t1 drop column c1,add column c1 varchar(20);"
+	sql = `/* 这是一条注释 */
+	alter table t1 drop column c1,add column c1 varchar(20);`
 	s.testErrorCode(c, sql)
 
 	sql = "alter table t1 drop column c1,add column c1 varchar(20) comment '123';"
 	s.testErrorCode(c, sql)
 
-	sql = "alter table t1 add column c2 varchar(20) comment '!@#$%^&*()_+[]{}\\|;:\",.<>/?';"
+	sql = `-- 这是一条注释
+	alter table t1 add column c2 varchar(20) comment '!@#$%^&*()_+[]{}\\|;:",.<>/?';`
 	s.testErrorCode(c, sql)
 
 	sql = "alter table t1 add column c3 varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";"


### PR DESCRIPTION
添加对各种ALTER语法格式的支持
例如:
```sql
-- 这是一条注释
alter table t1 add column c2 varchar(20) comment '!@#$%^&*()_+[]{}\\|;:",.<>/?';
```
```sql
alter table t1 add column `c5` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";  -- 测试注释
```