### PR TITLE
update: 完善数值类型的显示宽度审核 (#162)

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11729,10 +11729,8 @@ yynewstate:
 		{
 			x := types.NewFieldType(yyS[yypt-1].item.(byte))
 			x.Flen = yyS[yypt-0].item.(int)
-			if x.Flen == types.UnspecifiedLength || x.Flen == 0 {
+			if x.Flen == types.UnspecifiedLength {
 				x.Flen = 1
-			} else if x.Flen > 64 {
-				yylex.AppendError(ErrTooBigDisplayWidth.GenWithStackByArgs(x.Flen))
 			}
 			parser.yyVAL.item = x
 		}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6779,10 +6779,8 @@ NumericType:
 	{
 		x := types.NewFieldType($1.(byte))
 		x.Flen = $2.(int)
-		if x.Flen == types.UnspecifiedLength || x.Flen == 0 {
+		if x.Flen == types.UnspecifiedLength {
 			x.Flen = 1
-		} else if x.Flen > 64 {
-			yylex.AppendError(ErrTooBigDisplayWidth.GenWithStackByArgs(x.Flen))
 		}
 		$$ = x
 	}

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4655,9 +4655,10 @@ func (s *session) mysqlCheckField(t *TableInfo, field *ast.ColumnDef) {
 		}
 	}
 
-	if isIncorrectName(field.Name.Name.O) {
-		s.AppendErrorNo(ER_WRONG_COLUMN_NAME, field.Name.Name)
-	}
+	// if isIncorrectName(field.Name.Name.O) {
+	// 	s.AppendErrorNo(ER_WRONG_COLUMN_NAME, field.Name.Name)
+	// }
+
 	//text/blob/json 字段禁止设置NOT NULL
 	if (types.IsTypeBlob(field.Tp.Tp) || field.Tp.Tp == mysql.TypeJSON) && notNullFlag {
 		s.AppendErrorNo(ER_TEXT_NOT_NULLABLE_ERROR, field.Name.Name, tableName)
@@ -4687,6 +4688,7 @@ func (s *session) mysqlCheckField(t *TableInfo, field *ast.ColumnDef) {
 		s.AppendErrorNo(ER_WITH_DEFAULT_ADD_COLUMN, field.Name.Name.O, tableName)
 	}
 
+	s.checkColumn(field)
 	// if (thd->variables.sql_mode & MODE_NO_ZERO_DATE &&
 	//        is_timestamp_type(field->sql_type) && !field->def &&
 	//        (field->flags & NOT_NULL_FLAG) &&

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -1329,3 +1329,26 @@ func (s *testSessionIncExecSuite) TestAlterTableGhost(c *C) {
 	sql = "alter table t1 add column `c5` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";  -- 测试注释"
 	s.testErrorCode(c, sql)
 }
+
+// TestDisplayWidth 测试列指定长度参数
+func (s *testSessionIncExecSuite) TestDisplayWidth(c *C) {
+	sql := ""
+	config.GetGlobalConfig().Inc.CheckColumnComment = false
+	config.GetGlobalConfig().Inc.CheckTableComment = false
+	config.GetGlobalConfig().Inc.EnableEnumSetBit = true
+
+	s.mustRunExec(c, "drop table if exists t1;")
+	// 数据类型 警告
+	sql = `create table t1(c1 bit(64),
+	c2 tinyint(255),
+	c3 smallint(255),
+	c4 mediumint(255),
+	c5 int(255),
+	c6 bigint(255) );`
+	s.testErrorCode(c, sql)
+
+	// 数据类型 警告
+	sql = `alter table t1 add column c11 tinyint(255);`
+	s.testErrorCode(c, sql)
+
+}

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2683,3 +2683,36 @@ func (s *testSessionIncSuite) TestGetAlterTablePostPart(c *C) {
 		c.Assert(out, Equals, row.outGhost, Commentf("%v", row.sql))
 	}
 }
+
+// TestDisplayWidth 测试列指定长度参数
+func (s *testSessionIncSuite) TestDisplayWidth(c *C) {
+	sql := ""
+	config.GetGlobalConfig().Inc.CheckColumnComment = false
+	config.GetGlobalConfig().Inc.CheckTableComment = false
+	config.GetGlobalConfig().Inc.EnableEnumSetBit = true
+
+	s.mustRunExec(c, "drop table if exists t1;")
+	// 数据类型 警告
+	sql = `create table t1(c1 bit(100),
+	c2 tinyint(1000),
+	c3 smallint(1000),
+	c4 mediumint(1000),
+	c5 int(1000),
+	c6 bigint(1000) );`
+	s.testErrorCode(c, sql,
+		session.NewErrf("Too big display width for column '%s' (max = 64).", "c1"),
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c2"),
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c3"),
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c4"),
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c5"),
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c6"),
+	)
+
+	// 数据类型 警告
+	sql = `create table t1(id int);
+	alter table t1 add column c1 tinyint(1000);
+	`
+	s.testErrorCode(c, sql,
+		session.NewErrf("Too big display width for column '%s' (max = 255).", "c1"))
+
+}


### PR DESCRIPTION
完善数据类型的显示宽度审核，如以下SQL：
```sql
CREATE TABLE t1(c1 bit(100), 
c2 tinyint(1000), 
c3 smallint(1000), 
c4 mediumint(1000), 
c5 int(1000), 
c6 bigint(1000));
```