### PR TITLE
new: 添加osc参数max-flow-ctl,以便PXC集群执行pt (#170)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -420,7 +420,7 @@ type Osc struct {
 	OscMaxLag int `toml:"osc_max_lag" json:"osc_max_lag"`
 
 	// 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本）
-	OscMaxFlowCtl float32 `toml:"osc_max_flow_ctl" json:"osc_max_flow_ctl"`
+	OscMaxFlowCtl int `toml:"osc_max_flow_ctl" json:"osc_max_flow_ctl"`
 
 	// 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 	OscCheckAlter bool `toml:"osc_check_alter" json:"osc_check_alter"`

--- a/config/config.go
+++ b/config/config.go
@@ -419,6 +419,9 @@ type Osc struct {
 	// 对应参数pt-online-schema-change中的参数--max-lag。默认值：3
 	OscMaxLag int `toml:"osc_max_lag" json:"osc_max_lag"`
 
+	// 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本）
+	OscMaxFlowCtl float32 `toml:"osc_max_flow_ctl" json:"osc_max_flow_ctl"`
+
 	// 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 	OscCheckAlter bool `toml:"osc_check_alter" json:"osc_check_alter"`
 
@@ -773,6 +776,7 @@ var defaultConf = Config{
 		OscAlterForeignKeysMethod:  "none",
 		OscRecursionMethod:         "processlist",
 		OscMaxLag:                  3,
+		OscMaxFlowCtl:              -1,
 		OscCheckAlter:              true,
 		OscCheckReplicationFilters: true,
 		OscCheckUniqueKeyChange:    true,

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -110,6 +110,8 @@ osc_recursion_method = "processlist"
 # 对应参数pt-online-schema-change中的参数--max-lag。默认值：3
 osc_max_lag = 3
 
+# 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本,会自动检测)
+osc_max_flow_ctl = -1
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true
 

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -112,6 +112,7 @@ osc_max_lag = 3
 
 # 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本,会自动检测)
 osc_max_flow_ctl = -1
+
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -386,6 +386,9 @@ osc_recursion_method = "processlist"
 # 对应参数pt-online-schema-change中的参数--max-lag。默认值：3
 osc_max_lag = 3
 
+# 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本,会自动检测)
+osc_max_flow_ctl = -1
+
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true
 

--- a/session/osc.go
+++ b/session/osc.go
@@ -168,6 +168,11 @@ func (s *session) mysqlExecuteAlterTableOsc(r *Record) {
 	buf.WriteString(" --max-lag=")
 	buf.WriteString(fmt.Sprintf("%d", s.Osc.OscMaxLag))
 
+	if s.IsClusterNode && s.DBVersion > 50600 && s.Osc.OscMaxFlowCtl >= 0 {
+		buf.WriteString(" --max-flow-ctl=")
+		buf.WriteString(fmt.Sprintf("%f", s.Osc.OscMaxFlowCtl))
+	}
+
 	buf.WriteString(" --no-version-check ")
 	buf.WriteString(" --recursion-method=")
 	buf.WriteString(s.Osc.OscRecursionMethod)

--- a/session/osc.go
+++ b/session/osc.go
@@ -170,7 +170,7 @@ func (s *session) mysqlExecuteAlterTableOsc(r *Record) {
 
 	if s.IsClusterNode && s.DBVersion > 50600 && s.Osc.OscMaxFlowCtl >= 0 {
 		buf.WriteString(" --max-flow-ctl=")
-		buf.WriteString(fmt.Sprintf("%f", s.Osc.OscMaxFlowCtl))
+		buf.WriteString(fmt.Sprintf("%d", s.Osc.OscMaxFlowCtl))
 	}
 
 	buf.WriteString(" --no-version-check ")

--- a/session/session.go
+++ b/session/session.go
@@ -243,6 +243,8 @@ type session struct {
 	innodbLargePrefix bool
 	// 目标数据库的lower-case-table-names设置, 默认值为1,即不区分大小写
 	LowerCaseTableNames int
+	// PXC集群节点
+	IsClusterNode bool
 }
 
 // DDLOwnerChecker returns s.ddlOwnerChecker.

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -44,6 +44,8 @@ func (s *testSessionIncExecSuite) SetUpSuite(c *C) {
 	inc.EnableFingerprint = true
 	inc.SqlSafeUpdates = 0
 	inc.EnableDropTable = true
+
+	config.GetGlobalConfig().Osc.OscMaxFlowCtl = 1
 }
 
 func (s *testSessionIncExecSuite) TearDownSuite(c *C) {


### PR DESCRIPTION
添加参数 `osc_max_flow_ctl` ，对应pt参数 `--max-flow-ctl`。

该参数要求PXC数据库版本大于5.6。已自动添加该处理。

[pt max-flow-ctl参数说明](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html#cmdoption-pt-online-schema-change-max-flow-ctl)