### PR TITLE
update: 添加where条件中的值表达式审核,避免无效表达式误更新 (#178)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -652,6 +652,7 @@ type IncLevel struct {
 	ErJsonTypeSupport               int8 `toml:"er_json_type_support"`
 	ErrImplicitTypeConversion       int8 `toml:"er_implicit_type_conversion"`
 	ErrJoinNoOnCondition            int8 `toml:"er_join_no_on_condition"`
+	ErrUseValueExpr                 int8 `toml:"er_use_value_expr"`
 	ErrWrongAndExpr                 int8 `toml:"er_wrong_and_expr"`
 }
 
@@ -863,6 +864,7 @@ var defaultConf = Config{
 		ErJsonTypeSupport:               2,
 		ErrImplicitTypeConversion:       1,
 		ErrJoinNoOnCondition:            1,
+		ErrUseValueExpr:                 1,
 		ErrWrongAndExpr:                 1,
 	},
 }

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -353,6 +353,7 @@ er_with_default_add_column = 1
 er_with_insert_field = 1
 er_with_limit_condition = 1
 er_with_orderby_condition = 1
+er_use_value_expr = 1
 er_wrong_and_expr = 1
 
 [osc]

--- a/session/errors.go
+++ b/session/errors.go
@@ -204,6 +204,7 @@ const (
 	ErrFkDupName
 	ErrJoinNoOnCondition
 	ErrImplicitTypeConversion
+	ErrUseValueExpr
 	ER_ERROR_LAST
 )
 
@@ -375,6 +376,7 @@ var ErrorsDefault = map[ErrorCode]string{
 	ErrFkDupName:                   "Duplicate foreign key constraint name '%s'",
 	ErrJoinNoOnCondition:           "set the on clause for join statement.",
 	ErrImplicitTypeConversion:      "Implicit type conversion is not allowed(column '%s.%s',type '%s').",
+	ErrUseValueExpr:                "Please confirm if you want to use value expression in where condition.",
 	ER_ERROR_LAST:                  "TheLastError,ByeBye",
 }
 
@@ -538,6 +540,7 @@ var ErrorsChinese = map[ErrorCode]string{
 	ErrWrongAndExpr:                        "可能是错误语法!更新多个字段时请使用逗号分隔.",
 	ErrJoinNoOnCondition:                   "join语句请指定on子句.",
 	ErrImplicitTypeConversion:              "不允许隐式类型转换(列'%s.%s',类型'%s').",
+	ErrUseValueExpr:                        "请确认是否要在where条件中使用值表达式.",
 }
 
 func GetErrorLevel(code ErrorCode) uint8 {
@@ -598,6 +601,7 @@ func GetErrorLevel(code ErrorCode) uint8 {
 		ER_DATETIME_DEFAULT,
 		ErrWrongAndExpr,
 		ErrImplicitTypeConversion,
+		ErrUseValueExpr,
 		ER_WITH_INSERT_FIELD:
 		return 1
 
@@ -1023,6 +1027,8 @@ func (e ErrorCode) String() string {
 		return "er_join_no_on_condition"
 	case ErrImplicitTypeConversion:
 		return "er_implicit_type_conversion"
+	case ErrUseValueExpr:
+		return "er_use_value_expr"
 	case ER_ERROR_LAST:
 		return "er_error_last"
 	}

--- a/session/session_inception_common_test.go
+++ b/session/session_inception_common_test.go
@@ -263,6 +263,8 @@ inception_magic_commit;`
 	res := s.tk.MustQueryInc(fmt.Sprintf(a, s.getAddr(), s.realRowCount, s.useDB, sql))
 
 	for _, row := range res.Rows() {
+		c.Assert(strings.Contains(row[3].(string), "Execute Successfully"),
+			Equals, true, Commentf("%v", res.Rows()))
 		c.Assert(row[2], Not(Equals), "2", Commentf("%v", row))
 	}
 
@@ -291,6 +293,8 @@ inception_magic_commit;`
 
 	// 需要成功执行
 	for _, row := range res.Rows() {
+		// c.Assert(strings.Contains(row[3].(string), "Backup Successfully"),
+		// 	Equals, true, Commentf("%v", res.Rows()))
 		c.Assert(row[2], Not(Equals), "2", Commentf("%v", row))
 	}
 

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -84,14 +84,20 @@ func (s *testSessionIncExecSuite) testErrorCode(c *C, sql string, errors ...*ses
 		}
 		c.Assert(row[4], Equals, strings.Join(errMsgs, "\n"), Commentf("%v", row))
 	}
-
-	c.Assert(row[2], Equals, strconv.Itoa(errCode), Commentf("%v", res.Rows()))
+	// 没有错误时允许有警告
+	// if errCode == 0 {
+	// 	c.Assert(row[2], Not(Equals), "2", Commentf("%v", res.Rows()))
+	// } else {
+	// 	c.Assert(row[2], Equals, strconv.Itoa(errCode), Commentf("%v", res.Rows()))
+	// }
 	// 无错误时需要校验结果是否标记为已执行
 	if errCode == 0 {
 		c.Assert(strings.Contains(row[3].(string), "Execute Successfully"), Equals, true, Commentf("%v", res.Rows()))
 		for _, row := range res.Rows() {
 			c.Assert(row[2], Not(Equals), "2", Commentf("%v", res.Rows()))
 		}
+	} else {
+		c.Assert(row[2], Equals, strconv.Itoa(errCode), Commentf("%v", res.Rows()))
 	}
 
 	return res.Rows()
@@ -1366,4 +1372,37 @@ func (s *testSessionIncExecSuite) TestDisplayWidth(c *C) {
 	sql = `alter table t1 add column c11 tinyint(255);`
 	s.testErrorCode(c, sql)
 
+}
+
+func (s *testSessionIncExecSuite) TestWhereCondition(c *C) {
+	sql := ""
+	s.mustRunExec(c, "drop table if exists t1,t2;create table t1(id int);")
+
+	sql = "update t1 as tmp set tmp.id = 1 where 123;"
+	s.mustRunExec(c, sql)
+
+	sql = "update t1 as tmp set tmp.id = 1 where null;"
+	s.mustRunExec(c, sql)
+
+	sql = `
+	update t1 as tmp set tmp.id = 1 where 1+2;
+	update t1 as tmp set tmp.id = 1 where 1-2;
+	update t1 as tmp set tmp.id = 1 where 1*2;
+	update t1 as tmp set tmp.id = 1 where 1/2;
+	update t1 as tmp set tmp.id = 1 where 1&2;
+	update t1 as tmp set tmp.id = 1 where 1|2;
+	update t1 as tmp set tmp.id = 1 where 1^2;
+	update t1 as tmp set tmp.id = 1 where 1 div 2;
+	`
+	s.mustRunExec(c, sql)
+
+	sql = `
+	update t1 as tmp set tmp.id = 1 where 1+2=3;
+	update t1 as tmp set tmp.id = 1 where id is null;
+	update t1 as tmp set tmp.id = 1 where id is not null;
+	update t1 as tmp set tmp.id = 1 where 1=1;
+	update t1 as tmp set tmp.id = 1 where id in (1,2);
+	update t1 as tmp set tmp.id = 1 where id is true;
+	`
+	s.mustRunExec(c, sql)
 }

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -1378,31 +1378,31 @@ func (s *testSessionIncExecSuite) TestWhereCondition(c *C) {
 	sql := ""
 	s.mustRunExec(c, "drop table if exists t1,t2;create table t1(id int);")
 
-	sql = "update t1 as tmp set tmp.id = 1 where 123;"
+	sql = "update t1 set id = 1 where 123;"
 	s.mustRunExec(c, sql)
 
-	sql = "update t1 as tmp set tmp.id = 1 where null;"
+	sql = "update t1 set id = 1 where null;"
 	s.mustRunExec(c, sql)
 
 	sql = `
-	update t1 as tmp set tmp.id = 1 where 1+2;
-	update t1 as tmp set tmp.id = 1 where 1-2;
-	update t1 as tmp set tmp.id = 1 where 1*2;
-	update t1 as tmp set tmp.id = 1 where 1/2;
-	update t1 as tmp set tmp.id = 1 where 1&2;
-	update t1 as tmp set tmp.id = 1 where 1|2;
-	update t1 as tmp set tmp.id = 1 where 1^2;
-	update t1 as tmp set tmp.id = 1 where 1 div 2;
+	delete from t1 where 1+2;
+	delete from t1 where 1-2;
+	delete from t1 where 1*2;
+	delete from t1 where 1/2;
+	update t1 set id = 1 where 1&2;
+	update t1 set id = 1 where 1|2;
+	update t1 set id = 1 where 1^2;
+	update t1 set id = 1 where 1 div 2;
 	`
 	s.mustRunExec(c, sql)
 
 	sql = `
-	update t1 as tmp set tmp.id = 1 where 1+2=3;
-	update t1 as tmp set tmp.id = 1 where id is null;
-	update t1 as tmp set tmp.id = 1 where id is not null;
-	update t1 as tmp set tmp.id = 1 where 1=1;
-	update t1 as tmp set tmp.id = 1 where id in (1,2);
-	update t1 as tmp set tmp.id = 1 where id is true;
+	update t1 set id = 1 where 1+2=3;
+	update t1 set id = 1 where id is null;
+	update t1 set id = 1 where id is not null;
+	update t1 set id = 1 where 1=1;
+	update t1 set id = 1 where id in (1,2);
+	update t1 set id = 1 where id is true;
 	`
 	s.mustRunExec(c, sql)
 }

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2858,3 +2858,51 @@ func (s *testSessionIncSuite) TestBlobAndText(c *C) {
 		session.NewErr(session.ER_USE_TEXT_OR_BLOB, "c4"))
 
 }
+
+func (s *testSessionIncSuite) TestWhereCondition(c *C) {
+	sql := ""
+	s.mustRunExec(c, "drop table if exists t1,t2;create table t1(id int);")
+
+	sql = "update t1 as tmp set tmp.id = 1 where 123;"
+	config.GetGlobalConfig().IncLevel.ErrUseValueExpr = 0
+	s.testErrorCode(c, sql)
+
+	config.GetGlobalConfig().IncLevel.ErrUseValueExpr = 1
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrUseValueExpr))
+
+	sql = "update t1 as tmp set tmp.id = 1 where null;"
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrUseValueExpr))
+
+	sql = `
+	update t1 as tmp set tmp.id = 1 where 1+2;
+	update t1 as tmp set tmp.id = 1 where 1-2;
+	update t1 as tmp set tmp.id = 1 where 1*2;
+	update t1 as tmp set tmp.id = 1 where 1/2;
+	update t1 as tmp set tmp.id = 1 where 1&2;
+	update t1 as tmp set tmp.id = 1 where 1|2;
+	update t1 as tmp set tmp.id = 1 where 1^2;
+	update t1 as tmp set tmp.id = 1 where 1 div 2;
+	`
+	s.testSQLError(c, sql,
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+		session.NewErr(session.ErrUseValueExpr),
+	)
+
+	sql = `
+	update t1 as tmp set tmp.id = 1 where 1+2=3;
+	update t1 as tmp set tmp.id = 1 where id is null;
+	update t1 as tmp set tmp.id = 1 where id is not null;
+	update t1 as tmp set tmp.id = 1 where 1=1;
+	update t1 as tmp set tmp.id = 1 where id in (1,2);
+	update t1 as tmp set tmp.id = 1 where id is true;
+	`
+	s.testSQLError(c, sql)
+}

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -1559,7 +1559,7 @@ func (s *testSessionIncSuite) TestUpdate(c *C) {
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ER_TABLE_NOT_EXISTED_ERROR, "test_inc.t1"))
 
-	sql = "create table t1(id int);update t1 as tmp set tmp.id = 1;"
+	sql = "create table t1(id int);update t1 set id = 1;"
 	s.testErrorCode(c, sql)
 
 	sql = "create table t1(id int);update t1 as tmp set t1.id = 1;"
@@ -2863,7 +2863,7 @@ func (s *testSessionIncSuite) TestWhereCondition(c *C) {
 	sql := ""
 	s.mustRunExec(c, "drop table if exists t1,t2;create table t1(id int);")
 
-	sql = "update t1 as tmp set tmp.id = 1 where 123;"
+	sql = "update t1 set id = 1 where 123;"
 	config.GetGlobalConfig().IncLevel.ErrUseValueExpr = 0
 	s.testErrorCode(c, sql)
 
@@ -2871,19 +2871,19 @@ func (s *testSessionIncSuite) TestWhereCondition(c *C) {
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ErrUseValueExpr))
 
-	sql = "update t1 as tmp set tmp.id = 1 where null;"
+	sql = "update t1 set id = 1 where null;"
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ErrUseValueExpr))
 
 	sql = `
-	update t1 as tmp set tmp.id = 1 where 1+2;
-	update t1 as tmp set tmp.id = 1 where 1-2;
-	update t1 as tmp set tmp.id = 1 where 1*2;
-	update t1 as tmp set tmp.id = 1 where 1/2;
-	update t1 as tmp set tmp.id = 1 where 1&2;
-	update t1 as tmp set tmp.id = 1 where 1|2;
-	update t1 as tmp set tmp.id = 1 where 1^2;
-	update t1 as tmp set tmp.id = 1 where 1 div 2;
+	update t1 set id = 1 where 1+2;
+	update t1 set id = 1 where 1-2;
+	update t1 set id = 1 where 1*2;
+	delete from t1 where 1/2;
+	delete from t1 where 1&2;
+	delete from t1 where 1|2;
+	delete from t1 where 1^2;
+	delete from t1 where 1 div 2;
 	`
 	s.testSQLError(c, sql,
 		session.NewErr(session.ErrUseValueExpr),
@@ -2897,12 +2897,12 @@ func (s *testSessionIncSuite) TestWhereCondition(c *C) {
 	)
 
 	sql = `
-	update t1 as tmp set tmp.id = 1 where 1+2=3;
-	update t1 as tmp set tmp.id = 1 where id is null;
-	update t1 as tmp set tmp.id = 1 where id is not null;
-	update t1 as tmp set tmp.id = 1 where 1=1;
-	update t1 as tmp set tmp.id = 1 where id in (1,2);
-	update t1 as tmp set tmp.id = 1 where id is true;
+	update t1 set id = 1 where 1+2=3;
+	update t1 set id = 1 where id is null;
+	update t1 set id = 1 where id is not null;
+	update t1 set id = 1 where 1=1;
+	update t1 set id = 1 where id in (1,2);
+	update t1 set id = 1 where id is true;
 	`
 	s.testSQLError(c, sql)
 }


### PR DESCRIPTION
审核以下形式的SQL(仅`UPDATE`和`DELETE`)：

```sql
update t1 set c1 = 1 where 123;
update t1 set c1 = 1 where null;
update t1 set c1 = 1 where 1+2;
update t1 set c1 = 1 where 1-2;
update t1 set c1 = 1 where 1*2;
delete from t1 where 1/2;
delete from t1 set c1 = 1 where 1&2;
delete from t1 set c1 = 1 where 1|2;
delete from t1 set c1 = 1 where 1^2;
delete from t1 set c1 = 1 where 1 div 2;
```

审核结果如下(隐藏了部分列)：
order_id |  stage  | error_level |   stage_status   |         error_message        |                    sql      
-----|------|------|-----------|--------------|----------------------------
1     | CHECKED |      0      | Audit Completed |          None         |             use test
2     | CHECKED |      1      | Audit Completed |          Please confirm if you want to use value expression in where condition. |      update t1 set id = 1 where 123;

中文结果：
order_id |  stage  | error_level |   stage_status   |         error_message        |                    sql      
-----|------|------|-----------|--------------|----------------------------
1     | CHECKED |      0      | Audit Completed |          None         |             use test
2     | CHECKED |      1      | Audit Completed |          请确认是否要在where条件中使用值表达式. |      update t1 set id = 1 where 123;
