### PR TITLE
update: 添加参数ignore_sighup,默认忽略终端连接断开信号

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,9 @@ type Config struct {
 
 	// 是否跳过用户权限校验
 	SkipGrantTable bool `toml:"skip_grant_table" json:"skip_grant_table"`
+
+	// 忽略终端连接断开信号
+	IgnoreSighup bool `toml:"ignore_sighup" json:"ignore_sighup"`
 }
 
 // Log is the log section of config.
@@ -734,6 +737,7 @@ var defaultConf = Config{
 	// 默认跳过权限校验 2019-1-26
 	// 为配置方便,在config节点也添加相同参数
 	SkipGrantTable: true,
+	IgnoreSighup:   true,
 	Security: Security{
 		SkipGrantTable: true,
 	},

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -8,6 +8,9 @@ port = 4000
 # TiDB数据库目录
 path = "/tmp/tidb"
 
+# 忽略终端连接断开信号
+ignore_sighup = true
+
 [log]
 # 日志级别: debug, info, warn, error, fatal.
 level = "info"

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -50,6 +50,9 @@ compatible-kill-query = false
 
 skip_grant_table = true
 
+# 忽略终端连接断开信号
+ignore_sighup = true
+
 [log]
 # Log level: debug, info, warn, error, fatal.
 level = "info"

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -129,7 +129,7 @@ func main() {
 	setupBinlogClient()
 	createStoreAndDomain()
 	createServer()
-	signal.SetupSignalHandler(serverShutdown)
+	signal.SetupSignalHandler(cfg.IgnoreSighup, serverShutdown)
 
 	// 在启动完成后关闭DDL线程(goInception用不到该线程)
 	ddl := dom.DDL()


### PR DESCRIPTION
终端控制进程结束(终端连接断开)时 会自动发送 `SIGHUP` 信号量以关闭终端子进程，
goinception添加特殊处理，忽略该信号。

为避免该更新产生异常影响，添加新参数 `ignore_sighup` 用以开关该特性。
默认为`true`，开启该特性，即默认 `忽略` SIGHUP信号量


**重要：该参数设置位置和 `port` 或 `[inc]` 配置`同级`。**
可参考 配置文件示例 [config.toml.example](https://github.com/hanchuanchuan/goInception/blob/master/config/config.toml.example)
