### PR TITLE
添加lock_wait_timeout 控制 pt-osc 等待meta lock 时间，默认3s

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -398,6 +398,9 @@ type Osc struct {
 	// 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 	OscCheckAlter bool `toml:"osc_check_alter" json:"osc_check_alter"`
 
+	// 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
+	OscLockWaitTimeout int `toml:"osc_lock_wait_timeout" json:"osc_lock_wait_timeout"`
+
 	// 对应参数pt-online-schema-change中的参数--[no]check-replication-filters。默认值：ON
 	OscCheckReplicationFilters bool `toml:"osc_check_replication_filters" json:"osc_check_replication_filters"`
 	// 是否检查唯一索引,默认检查,如果是,则禁止
@@ -745,6 +748,7 @@ var defaultConf = Config{
 		OscRecursionMethod:         "processlist",
 		OscMaxLag:                  3,
 		OscMaxFlowCtl:              -1,
+		OscLockWaitTimeout:         3,
 		OscCheckAlter:              true,
 		OscCheckReplicationFilters: true,
 		OscCheckUniqueKeyChange:    true,

--- a/config/config.go
+++ b/config/config.go
@@ -398,7 +398,7 @@ type Osc struct {
 	// 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 	OscCheckAlter bool `toml:"osc_check_alter" json:"osc_check_alter"`
 
-	// 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
+	// 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=60s
 	OscLockWaitTimeout int `toml:"osc_lock_wait_timeout" json:"osc_lock_wait_timeout"`
 
 	// 对应参数pt-online-schema-change中的参数--[no]check-replication-filters。默认值：ON

--- a/config/config.go
+++ b/config/config.go
@@ -748,7 +748,7 @@ var defaultConf = Config{
 		OscRecursionMethod:         "processlist",
 		OscMaxLag:                  3,
 		OscMaxFlowCtl:              -1,
-		OscLockWaitTimeout:         3,
+		OscLockWaitTimeout:         60,
 		OscCheckAlter:              true,
 		OscCheckReplicationFilters: true,
 		OscCheckUniqueKeyChange:    true,

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -116,6 +116,9 @@ osc_max_lag = 3
 # 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本,会自动检测)
 osc_max_flow_ctl = -1
 
+# 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
+osc_lock_wait_timeout = 3
+
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true
 

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -117,7 +117,7 @@ osc_max_lag = 3
 osc_max_flow_ctl = -1
 
 # 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
-osc_lock_wait_timeout = 3
+osc_lock_wait_timeout = 60
 
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -344,6 +344,9 @@ osc_max_lag = 3
 # 类似--max-lag，检查集群暂停流量控制所花费的平均时间（仅适用于PXC 5.6及以上版本,会自动检测)
 osc_max_flow_ctl = -1
 
+# 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
+osc_lock_wait_timeout = 3
+
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -345,7 +345,7 @@ osc_max_lag = 3
 osc_max_flow_ctl = -1
 
 # 对应参数pt-online-schema-change中的参数 --set-vars lock_wait_timeout=?
-osc_lock_wait_timeout = 3
+osc_lock_wait_timeout = 60
 
 # 对应参数pt-online-schema-change中的参数--[no]check-alter。默认值：ON
 osc_check_alter = true

--- a/session/osc.go
+++ b/session/osc.go
@@ -113,6 +113,7 @@ func (s *session) mysqlExecuteAlterTableOsc(r *Record) {
 	if s.osc.OscPrintSql {
 		buf.WriteString(" --print ")
 	}
+	buf.WriteString(fmt.Sprintf("  --set-vars lock_wait_timeout=%d", s.osc.OscLockWaitTimeout))
 	buf.WriteString(" --charset=utf8 ")
 	buf.WriteString(" --chunk-time ")
 	buf.WriteString(fmt.Sprintf("%g ", s.osc.OscChunkTime))


### PR DESCRIPTION
相关ISSUE 见[pt-online-schema-change 中 rename 操作设置超时时间](https://github.com/hanchuanchuan/goInception/issues/214)