### PR TITLE
fix: 修复MariaDB可能出现dml未备份成功的问题

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 // indirect
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
-	github.com/etcd-io/gofail v0.0.0-20180808172546-51ce9a71510a // indirect
+	github.com/etcd-io/gofail v0.0.0-20180808172546-51ce9a71510a
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/session/core.go
+++ b/session/core.go
@@ -108,7 +108,9 @@ func (s *session) init() {
 	s.inc.Lang = strings.Replace(strings.ToLower(s.inc.Lang), "-", "_", 1)
 
 	s.sqlFingerprint = nil
+
 	s.dbType = DBTypeMysql
+	s.dbVersion = 0
 
 	// 自定义审核级别,通过解析config.GetGlobalConfig().IncLevel生成
 	s.parseIncLevel()

--- a/session/session_inception_backup_test.go
+++ b/session/session_inception_backup_test.go
@@ -79,7 +79,7 @@ func (s *testSessionIncBackupSuite) TestDropTable(c *C) {
 	row = s.rows[s.getAffectedRows()-1]
 	backup = s.query("t1", row[7].(string))
 	// mysql 8.0版本默认字符集改成了utf8mb4
-	if s.DBVersion < 80000 {
+	if s.DBVersion < 80000 || s.DBType == DBTypeMariaDB {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8;")
 	} else {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;")
@@ -89,7 +89,7 @@ func (s *testSessionIncBackupSuite) TestDropTable(c *C) {
 	s.mustRunBackup(c, "drop table t1;")
 	row = s.rows[s.getAffectedRows()-1]
 	backup = s.query("t1", row[7].(string))
-	if s.DBVersion < 80000 {
+	if s.DBVersion < 80000 || s.DBType == DBTypeMariaDB {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
 	} else {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;")
@@ -99,7 +99,7 @@ func (s *testSessionIncBackupSuite) TestDropTable(c *C) {
 	s.mustRunBackup(c, "drop table t1;")
 	row = s.rows[s.getAffectedRows()-1]
 	backup = s.query("t1", row[7].(string))
-	if s.DBVersion < 80000 {
+	if s.DBVersion < 80000 || s.DBType == DBTypeMariaDB {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) NOT NULL DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8;")
 	} else {
 		c.Assert(backup, Equals, "CREATE TABLE `t1` (\n `id` int(11) NOT NULL DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;")
@@ -503,7 +503,7 @@ func (s *testSessionIncBackupSuite) TestMinimalUpdate(c *C) {
 func (s *testSessionIncBackupSuite) TestDelete(c *C) {
 
 	s.mustRunExec(c, `drop table if exists t1;
-	create table t1(id int,c1 int);
+	create table t1(id int primary key,c1 int);
 	insert into t1 values(1,1),(2,2);`)
 
 	s.mustRunBackup(c, "delete from t1 where id <= 2;")

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -198,12 +198,15 @@ func (s *testSessionIncExecSuite) TestCreateTable(c *C) {
 		indexMaxLength = 3072
 	}
 
+	config.GetGlobalConfig().Inc.EnableSetCharset = true
+	config.GetGlobalConfig().Inc.SupportCharset = "utf8,utf8mb4"
+
 	s.runExec("drop table if exists t1")
 	if s.innodbLargePrefix {
-		sql = "create table t1(c1 int,c2 varchar(400),c3 varchar(400),index idx_1(c1,c2))charset utf8;;"
+		sql = "create table t1(c1 int,c2 varchar(400),c3 varchar(400),index idx_1(c1,c2))charset utf8;"
 		s.testErrorCode(c, sql)
 	} else {
-		sql = "create table t1(c1 int,c2 varchar(400),c3 varchar(400),index idx_1(c1,c2))charset utf8;;"
+		sql = "create table t1(c1 int,c2 varchar(400),c3 varchar(400),index idx_1(c1,c2))charset utf8;"
 		s.testErrorCode(c, sql,
 			session.NewErr(session.ER_TOO_LONG_KEY, "idx_1", indexMaxLength))
 	}


### PR DESCRIPTION
MariaDB v10版本以上时可能出现DML执行成功, 但未生成备份的问题.

问题原因是MariaDB在v10版本的binlog移除了DML操作前的QueryEvent事件, 导致无法获取到DML操作的线程号connection_id. 