### PR TITLE
修复审核语句存在其他问题时列索引可能审核异常的问题

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4517,10 +4517,6 @@ func (s *session) checkCreateIndex(table *ast.TableName, IndexName string,
 	}
 	// }
 
-	if s.hasError() {
-		return
-	}
-
 	indexType := "BTREE"
 	if tp == ast.ConstraintSpatial {
 		indexType = "SPATIAL"
@@ -4547,8 +4543,7 @@ func (s *session) checkCreateIndex(table *ast.TableName, IndexName string,
 		t.Indexes = append(t.Indexes, index)
 	}
 
-	// !t.IsNew &&
-	if s.opt.Execute {
+	if !s.hasError() && s.opt.Execute {
 		var rollbackSql string
 		if IndexName == "PRIMARY" {
 			rollbackSql = fmt.Sprintf("DROP PRIMARY KEY,")

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -2773,7 +2773,7 @@ func (s *session) checkCreateTable(node *ast.CreateTableStmt, sql string) {
 		}
 	}
 
-	if s.inc.ColumnsMustHaveIndex != "" {
+	if !s.hasError() && s.inc.ColumnsMustHaveIndex != "" {
 		s.checkColumnsMustHaveindex(table)
 	}
 
@@ -3112,7 +3112,7 @@ func (s *session) checkAlterTable(node *ast.AlterTableStmt, sql string) {
 		}
 	}
 
-	if s.inc.ColumnsMustHaveIndex != "" {
+	if !s.hasError() && s.inc.ColumnsMustHaveIndex != "" {
 		tableCopy := s.getTableFromCache(node.Table.Schema.O, node.Table.Name.O, true)
 		s.checkColumnsMustHaveindex(tableCopy)
 	}
@@ -4515,7 +4515,10 @@ func (s *session) checkCreateIndex(table *ast.TableName, IndexName string,
 	if s.inc.MaxKeys > 0 && key_count >= int(s.inc.MaxKeys) {
 		s.appendErrorNo(ER_TOO_MANY_KEYS, t.Name, s.inc.MaxKeys)
 	}
-	// }
+
+	if s.hasError() {
+		return
+	}
 
 	indexType := "BTREE"
 	if tp == ast.ConstraintSpatial {
@@ -4543,7 +4546,7 @@ func (s *session) checkCreateIndex(table *ast.TableName, IndexName string,
 		t.Indexes = append(t.Indexes, index)
 	}
 
-	if !s.hasError() && s.opt.Execute {
+	if s.opt.Execute {
 		var rollbackSql string
 		if IndexName == "PRIMARY" {
 			rollbackSql = fmt.Sprintf("DROP PRIMARY KEY,")


### PR DESCRIPTION
修复 `columns_must_have_index` 审核项逻辑。

相关说明：
如果在建表时存在错误，则后续依赖于表结构的审核可能不准确（或者已无法做到准确）
（该问题是否触发取决于审核级别设置）

相关问题：#235