### PR TITLE
update: 优化索引可见性审核逻辑,以免后端数据库不支持(fix #247)

### DIFF
--- a/session/errors.go
+++ b/session/errors.go
@@ -207,6 +207,7 @@ const (
 	ErrJoinNoOnCondition
 	ErrImplicitTypeConversion
 	ErrUseValueExpr
+	ErrUseIndexVisibility
 	ER_ERROR_LAST
 )
 
@@ -381,6 +382,7 @@ var ErrorsDefault = map[ErrorCode]string{
 	ErrJoinNoOnCondition:           "set the on clause for join statement.",
 	ErrImplicitTypeConversion:      "Implicit type conversion is not allowed(column '%s.%s',type '%s').",
 	ErrUseValueExpr:                "Please confirm if you want to use value expression in where condition.",
+	ErrUseIndexVisibility:          "The back-end database does not support the index to specify the visible option.",
 	ER_ERROR_LAST:                  "TheLastError,ByeBye",
 }
 
@@ -547,6 +549,7 @@ var ErrorsChinese = map[ErrorCode]string{
 	ErrJoinNoOnCondition:                   "join语句请指定on子句.",
 	ErrImplicitTypeConversion:              "不允许隐式类型转换(列'%s.%s',类型'%s').",
 	ErrUseValueExpr:                        "请确认是否要在where条件中使用值表达式.",
+	ErrUseIndexVisibility:                  "后端数据库暂不支持索引指定visible选项",
 }
 
 func GetErrorLevel(code ErrorCode) uint8 {
@@ -1041,6 +1044,8 @@ func (e ErrorCode) String() string {
 		return "er_implicit_type_conversion"
 	case ErrUseValueExpr:
 		return "er_use_value_expr"
+	case ErrUseIndexVisibility:
+		return "er_use_index_visibility"
 	case ER_ERROR_LAST:
 		return "er_error_last"
 	}

--- a/session/session_inception_common_test.go
+++ b/session/session_inception_common_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/hanchuanchuan/goInception/session"
 	"github.com/hanchuanchuan/goInception/store/mockstore"
 	"github.com/hanchuanchuan/goInception/store/mockstore/mocktikv"
+	"github.com/hanchuanchuan/goInception/util/logutil"
 	"github.com/hanchuanchuan/goInception/util/testkit"
 	"github.com/hanchuanchuan/goInception/util/testleak"
+
 	"github.com/jinzhu/gorm"
 	. "github.com/pingcap/check"
 	repllog "github.com/siddontang/go-log/log"
@@ -181,7 +183,7 @@ func (s *testCommon) initSetUp(c *C) {
 
 	// 测试API接口时自动忽略之前的测试方法
 
-	log.Errorf("is api: %v", isAPI)
+	// log.Errorf("is api: %v", isAPI)
 	s.isAPI = isAPI
 	if isAPI {
 		s.sessionService = session.NewInception()
@@ -975,7 +977,13 @@ func (s *testCommon) parserStmt(sql string) ast.StmtNode {
 func (s *testCommon) reset() {
 	config.GetGlobalConfig().Inc = s.defaultInc
 	log.SetLevel(log.ErrorLevel)
-	log.SetReportCaller(true)
+	// log.SetReportCaller(true)
+
+	_ = logutil.InitLogger(&logutil.LogConfig{
+		Level:            "error",
+		Format:           "text",
+		DisableTimestamp: false,
+	})
 }
 
 // getAffectedRows 获取受影响行数, 区分api返回和mysql会话返回

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2257,6 +2257,16 @@ func (s *testSessionIncSuite) TestAlterTableAddIndex(c *C) {
 	sql = "CREATE TABLE geom (id int,g GEOMETRY NOT NULL);alter table geom add SPATIAL INDEX ix_1(id,g);"
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ER_TOO_MANY_KEY_PARTS, "ix_1", "geom", 1))
+
+	sql = `create table t1(id int,c1 int);
+		alter table t1 add index idx (c1) visible;`
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrUseIndexVisibility))
+
+	sql = `create table t1(id int,c1 int);
+		alter table t1 add index idx2 (c1) invisible;`
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrUseIndexVisibility))
 }
 
 func (s *testSessionIncSuite) TestAlterTableDropIndex(c *C) {

--- a/session/tidb_check.go
+++ b/session/tidb_check.go
@@ -495,15 +495,17 @@ func (s *session) checkOnlyFullGroupByWithGroupClause(sel *ast.SelectStmt, table
 		return nil
 	}
 
-	for _, errExprLoc := range notInGbyCols {
+	for field, errExprLoc := range notInGbyCols {
 		switch errExprLoc.Loc {
 		case ErrExprInSelect:
+			// getName(sel.Fields.Fields[errExprLoc.Offset])
 			s.appendErrorNo(ErrFieldNotInGroupBy, errExprLoc.Offset+1, errExprLoc.Loc,
-				sel.Fields.Fields[errExprLoc.Offset].Text())
+				field.Field)
 			return nil
 		case ErrExprInOrderBy:
+			// sel.OrderBy.Items[errExprLoc.Offset].Expr.Text()
 			s.appendErrorNo(ErrFieldNotInGroupBy, errExprLoc.Offset+1, errExprLoc.Loc,
-				sel.OrderBy.Items[errExprLoc.Offset].Expr.Text())
+				field.Field)
 			return nil
 		}
 		return nil


### PR DESCRIPTION
索引指定`VISIBLE/INVISIBLE`时是可以通过的，但VISIBLE选项仅在MySQL 8.0版本之后才支持，所以添加该审核规则。

```
-- 示例SQL
create table if not exists t1(id int primary key,c1 char(1));

ALTER TABLE t1
ADD INDEX idx_1 (c1 ASC) VISIBLE;
```