### PR TITLE
fix: 修复update指定表别名时审核错误的问题(fix #249)

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6333,7 +6333,11 @@ func (s *session) checkUpdate(node *ast.UpdateStmt, sql string) {
 			for _, l := range node.List {
 				// 未指定表别名时加默认设置
 				if l.Column.Table.L == "" && len(tableInfoList) == 1 {
-					l.Column.Table = model.NewCIStr(s.myRecord.TableInfo.Name)
+					if s.myRecord.TableInfo.AsName != "" {
+						l.Column.Table = model.NewCIStr(s.myRecord.TableInfo.AsName)
+					} else {
+						l.Column.Table = model.NewCIStr(s.myRecord.TableInfo.Name)
+					}
 				}
 
 				if s.checkFieldItem(l.Column, tableInfoList) {


### PR DESCRIPTION
以下`update`语句审核有误，会误报列不存在(指定了表别名但未使用)。
```sql
# table schema
create table if not exists t1(id int primary key,c1 int);

update t1 a set c1 = 2;
```