### PR TITLE
fix: 修复列歧义性检查对order by可能误报的bug

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -254,6 +254,9 @@ type session struct {
 	lowerCaseTableNames int
 	// PXC集群节点
 	isClusterNode bool
+
+	// 是否检查歧义性. 在order by时忽略该检查,其他时候正常开启
+	checkAmbiguous bool
 }
 
 func (s *session) getMembufCap() int {

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -1613,6 +1613,8 @@ func (s *testSessionIncSuite) TestSelect(c *C) {
 	s.testErrorCode(c, sql,
 		session.NewErr(session.ErrImplicitTypeConversion, "t1", "c1", "int"))
 
+	sql = `select id from t1 order by id;`
+	s.testErrorCode(c, sql)
 }
 
 func (s *testSessionIncSuite) TestSubSelect(c *C) {


### PR DESCRIPTION
#271 