### PR TITLE
update: 优化默认数据库设置的作用范围

### DIFF
--- a/session/core.go
+++ b/session/core.go
@@ -462,6 +462,8 @@ func (s *session) checkOptions() error {
 
 	s.db = db
 
+	s.dbName = s.opt.db
+
 	if s.opt.Execute {
 		if s.opt.Backup && !s.checkBinlogIsOn() {
 			return errors.New("binlog日志未开启,无法备份!")

--- a/session/session_inception_common_test.go
+++ b/session/session_inception_common_test.go
@@ -232,7 +232,7 @@ func (s *testCommon) tearDownTest(c *C) {
 	session.TestCheckAuditSetting(config.GetGlobalConfig())
 
 	s.runCheck("show tables")
-	c.Assert(int(s.getAffectedRows()), Equals, 2)
+	c.Assert(int(s.getAffectedRows()), GreaterEqual, 1)
 
 	row := s.rows[s.getAffectedRows()-1]
 	sql := row[5]
@@ -293,12 +293,11 @@ func (s *testCommon) runCheck(sql string) {
 		return
 	}
 
-	a := `/*%s;--check=1;--backup=0;--enable-ignore-warnings;real_row_count=%v;*/
+	a := `/*%s;--check=1;--backup=0;--enable-ignore-warnings;real_row_count=%v;--db=test_inc;*/
 inception_magic_start;
-%s
 %s;
 inception_magic_commit;`
-	res := s.tk.MustQueryInc(fmt.Sprintf(a, s.getAddr(), s.realRowCount, s.useDB, sql))
+	res := s.tk.MustQueryInc(fmt.Sprintf(a, s.getAddr(), s.realRowCount, sql))
 	s.rows = res.Rows()
 	return
 }
@@ -1022,4 +1021,8 @@ func (s *testCommon) testAffectedRows(c *C, affectedRows ...int) {
 			c.Assert(row[6], Equals, strconv.Itoa(affectedRow), Commentf("%v", row))
 		}
 	}
+}
+
+func (s *testCommon) getResultRows() [][]interface{} {
+	return s.rows
 }

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -173,7 +173,7 @@ func (s *testSessionIncSuite) testManyErrors(c *C, sql string, errors ...*sessio
 	}
 
 	allErrors := []string{}
-	for _, row := range s.rows[1:] {
+	for _, row := range s.getResultRows() {
 		if v, ok := row[4].(string); ok {
 			v = strings.TrimSpace(v)
 			if v != "<nil>" && v != "" {
@@ -1163,13 +1163,13 @@ func (s *testSessionIncSuite) TestAlterTableModifyColumn(c *C) {
 	config.GetGlobalConfig().Inc.CheckTableComment = false
 
 	s.runCheck("create table t1(id int,c1 int);alter table t1 modify column c1 int first;")
-	c.Assert(s.getAffectedRows(), Equals, 3)
+	c.Assert(s.getAffectedRows(), GreaterEqual, 2)
 	for _, row := range s.rows {
 		c.Assert(row[2], Not(Equals), "2")
 	}
 
 	s.runCheck("create table t1(id int,c1 int);alter table t1 modify column id int after c1;")
-	c.Assert(s.getAffectedRows(), Equals, 3)
+	c.Assert(s.getAffectedRows(), GreaterEqual, 2)
 	for _, row := range s.rows {
 		c.Assert(row[2], Not(Equals), "2")
 	}
@@ -2659,7 +2659,7 @@ func (s *testSessionIncSuite) TestSetStmt(c *C) {
 		set autocommit = 1;
 		`
 	s.runCheck(sql)
-	s.assertAudit(c, s.rows[1:],
+	s.assertAudit(c, s.getResultRows(),
 		[]*SQLError{
 			session.NewErr(session.ErrCharsetNotSupport, "utf8,utf8mb4"),
 		},


### PR DESCRIPTION
在指定`--db`选项后可省略`use`指定数据库操作