### PR TITLE
feature: 添加enable_any_statement选项以支持所有语法

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -258,9 +258,11 @@ type Inc struct {
 	CheckIdentifierUpper bool `toml:"check_identifier_upper" json:"check_identifier_upper"`
 
 	// 连接服务器的默认字符集,默认值为utf8mb4
-	DefaultCharset              string `toml:"default_charset" json:"default_charset"`
-	EnableAlterDatabase         bool   `toml:"enable_alter_database" json:"enable_alter_database"`
-	EnableAutoIncrementUnsigned bool   `toml:"enable_autoincrement_unsigned" json:"enable_autoincrement_unsigned"`
+	DefaultCharset      string `toml:"default_charset" json:"default_charset"`
+	EnableAlterDatabase bool   `toml:"enable_alter_database" json:"enable_alter_database"`
+	// 允许执行任意语法类型.该设置有安全要求,仅支持配置文件方式设置
+	EnableAnyStatement          bool `toml:"enable_any_statement" json:"enable_any_statement"`
+	EnableAutoIncrementUnsigned bool `toml:"enable_autoincrement_unsigned" json:"enable_autoincrement_unsigned"`
 	// 允许blob,text,json列设置为NOT NULL
 	EnableBlobNotNull   bool `toml:"enable_blob_not_null" json:"enable_blob_not_null"`
 	EnableBlobType      bool `toml:"enable_blob_type" json:"enable_blob_type"`
@@ -740,6 +742,7 @@ var defaultConf = Config{
 		EnableSetEngine:       true,
 		CheckTableComment:     false,
 		CheckColumnComment:    false,
+		EnableAnyStatement:    false,
 		EnableChangeColumn:    true,
 		CheckTimestampCount:   true,
 		EnableTimeStampType:   true,

--- a/session/core.go
+++ b/session/core.go
@@ -111,6 +111,18 @@ func (s *session) init() {
 	s.osc = config.GetGlobalConfig().Osc
 	s.ghost = config.GetGlobalConfig().Ghost
 
+	// 在开启goinception鉴权时.非root用户禁止启用EnableAnyStatement功能
+	// if !s.inc.SkipGrantTable {}
+	if s.inc.EnableAnyStatement {
+		if tmp := s.processInfo.Load(); tmp != nil {
+			if pi, ok := tmp.(util.ProcessInfo); ok {
+				if pi.User != "root" {
+					log.Errorf("user: %s", pi.User)
+					s.inc.EnableAnyStatement = false
+				}
+			}
+		}
+	}
 	s.inc.Lang = strings.Replace(strings.ToLower(s.inc.Lang), "-", "_", 1)
 
 	s.sqlFingerprint = nil

--- a/session/core.go
+++ b/session/core.go
@@ -117,7 +117,7 @@ func (s *session) init() {
 		if tmp := s.processInfo.Load(); tmp != nil {
 			if pi, ok := tmp.(util.ProcessInfo); ok {
 				if pi.User != "root" {
-					log.Errorf("user: %s", pi.User)
+					log.Warnf("Insufficient permissions to enable any statement! user: %s", pi.User)
 					s.inc.EnableAnyStatement = false
 				}
 			}

--- a/session/session.go
+++ b/session/session.go
@@ -863,6 +863,7 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 		Info:      sql,
 		OperState: "INIT",
 	}
+	log.Errorf("s.sessionVars.User: %#v", s.sessionVars.User)
 	if s.sessionVars.User != nil {
 		pi.User = s.sessionVars.User.Username
 		pi.Host = s.sessionVars.User.Hostname

--- a/session/session_inception_common_test.go
+++ b/session/session_inception_common_test.go
@@ -23,17 +23,20 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/hanchuanchuan/goInception/ast"
 	"github.com/hanchuanchuan/goInception/config"
 	"github.com/hanchuanchuan/goInception/domain"
 	"github.com/hanchuanchuan/goInception/kv"
+	"github.com/hanchuanchuan/goInception/mysql"
 	"github.com/hanchuanchuan/goInception/parser"
 	"github.com/hanchuanchuan/goInception/server"
 	"github.com/hanchuanchuan/goInception/session"
 	"github.com/hanchuanchuan/goInception/store/mockstore"
 	"github.com/hanchuanchuan/goInception/store/mockstore/mocktikv"
+	"github.com/hanchuanchuan/goInception/util/auth"
 	"github.com/hanchuanchuan/goInception/util/logutil"
 	"github.com/hanchuanchuan/goInception/util/testkit"
 	"github.com/hanchuanchuan/goInception/util/testleak"
@@ -151,6 +154,15 @@ func (s *testCommon) initSetUp(c *C) {
 	s.tk.Se.SetSessionManager(server)
 
 	s.session = s.tk.Se
+	vars := s.session.GetSessionVars()
+	if vars.User == nil {
+		vars.User = &auth.UserIdentity{
+			Username: "root",
+			Hostname: "127.0.0.1",
+		}
+	}
+	// 重新设置进程信息,写入user@host
+	s.session.SetProcessInfo("", time.Now(), mysql.ComQuery)
 
 	cfg := config.GetGlobalConfig()
 	_, localFile, _, _ := runtime.Caller(0)

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -1026,3 +1026,17 @@ func (s *testSessionIncExecSuite) TestWhereCondition(c *C) {
 	`
 	s.mustRunExec(c, sql)
 }
+
+func (s *testSessionIncExecSuite) TestExecAnyStatement(c *C) {
+	sql := ""
+	config.GetGlobalConfig().Inc.EnableAnyStatement = true
+	config.GetGlobalConfig().Inc.EnableDropTable = false
+
+	sql = "drop table if exists t1;create table t1(id int);drop table t1;"
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ER_CANT_DROP_TABLE, "t1"))
+
+	s.mustRunExec(c, "set global binlog_format = ROW;")
+	s.mustRunExec(c, "create user test1@'127.0.0.1' identified by '123';")
+	s.mustRunExec(c, "drop user test1@'127.0.0.1';")
+}


### PR DESCRIPTION
仅支持TiDB解析器可正常解析的语法.

安全上有以下强限制: 
1. 用户名必须为root(无论是否开启goinception鉴权功能).因此可通过不同用户名实现权限隔离.
2. 优化级低于现有的功能开关,如禁止删表的话(enable_drop_table=false),则即可允许所有语法也无法执行删除,尽可能保证数据安全性.
3. 该功能为只读变量,不允许通过会话级进行设置

**说明:** 若出现语法错误(在MySQL中正常时),可创建Issue来指出该语法,以便更新SQL解析器.