### PR TITLE
fix: 修复强制忽略osc的判断问题，语句中有任意需要使用osc执行的都不能忽略

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -3118,6 +3118,7 @@ func (s *session) checkAlterTable(node *ast.AlterTableStmt, sql string) {
 	if s.myRecord.useOsc && !hasRenameTable {
 		ignoreOsc := false
 		for _, alter := range node.Specs {
+			ignoreOsc = false
 			switch alter.Tp {
 			case ast.AlterTableOption:
 				for _, opt := range alter.Options {


### PR DESCRIPTION
目前的判断会导致有任意需要忽略的语句块就会忽略整个语句，比如删除索引重建会忽略osc执行
```
Inc.IgnoreOscAlterStmt = "drop index,drop partition"
sql = "alter table t1 drop index ix,add index ix2(c1);"
```