### PR TITLE
update: 放开DROP PARTITION的Restore解析

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -2020,17 +2020,17 @@ func (n *AlterTableSpec) Restore(ctx *RestoreCtx) error {
 	case AlterTableCoalescePartitions:
 		ctx.WriteKeyWord("COALESCE PARTITION ")
 		ctx.WritePlainf("%d", n.Num)
-	// case AlterTableDropPartition:
-	// 	ctx.WriteKeyWord("DROP PARTITION ")
-	// 	if n.IfExists {
-	// 		ctx.WriteKeyWord("IF EXISTS ")
-	// 	}
-	// 	for i, name := range n.PartitionNames {
-	// 		if i != 0 {
-	// 			ctx.WritePlain(",")
-	// 		}
-	// 		ctx.WriteName(name.O)
-	// 	}
+	case AlterTableDropPartition:
+		ctx.WriteKeyWord("DROP PARTITION ")
+		if n.IfExists {
+			ctx.WriteKeyWord("IF EXISTS ")
+		}
+		for i, name := range n.PartitionNames {
+			if i != 0 {
+				ctx.WritePlain(",")
+			}
+			ctx.WriteName(name.O)
+		}
 	case AlterTableTruncatePartition:
 		ctx.WriteKeyWord("TRUNCATE PARTITION ")
 		if n.OnAllPartitions {


### PR DESCRIPTION
不太清楚为何被禁用，开启后可用于支持osc忽略DROP PARTITION