### PR TITLE
update: 增加检测SQL的超时时间，避免真实影响行数检测对实例造成影响

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -365,6 +365,11 @@ type Inc struct {
 	// > 0 值表示，会话在执行SQL 时获取锁超时的时间
 	LockWaitTimeout int `toml:"lock_wait_timeout" json:"lock_wait_timeout"`
 
+	// 设置检测SQL时，会话变量
+	// -1 表示不做操作，基于远端数据库【默认值】
+	// > 0 值表示，会话在检测SQL的超时的时间
+	CheckMaxExecutionTime int `toml:"check_max_execution_time" json:"check_max_execution_time"`
+
 	// 支持的字符集
 	SupportCharset string `toml:"support_charset" json:"support_charset"`
 
@@ -750,6 +755,7 @@ var defaultConf = Config{
 		CheckIdentifierUpper:  false,
 		SqlSafeUpdates:        -1,
 		LockWaitTimeout:       -1,
+		CheckMaxExecutionTime: -1,
 		SupportCharset:        "utf8,utf8mb4",
 		SupportEngine:         "innodb",
 		Lang:                  "en-US",

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -94,6 +94,11 @@ sql_safe_updates = -1
 # > 0 值表示，会话在执行SQL 时获取锁超时的时间
 lock_wait_timeout = -1
 
+# 设置检测SQL时，会话变量
+# -1 表示不做操作，基于远端数据库【默认值】
+# > 0 值表示，会话在检测SQL的超时的时间
+check_max_execution_time = -1
+
 # 是否跳过goinception用户权限校验, 默认跳过
 skip_grant_table = true
 

--- a/session/core.go
+++ b/session/core.go
@@ -544,6 +544,11 @@ func (s *session) checkOptions() error {
 	s.setSqlSafeUpdates()
 	s.setLockWaitTimeout()
 
+	// 设置检测语句的执行时间
+	if s.opt.Check && s.dbType == DBTypeMysql && s.dbVersion >= 50708 {
+		s.setCheckMaxExecutionTime()
+	}
+
 	if s.opt.Backup && s.dbType == DBTypeTiDB {
 		s.appendErrorMessage("TiDB暂不支持备份功能.")
 	}


### PR DESCRIPTION
背景：
针对需要开启真实影响行数检测的场景，由于大多数审核检测还是在主库进行，这等同于是开放了在主库执行任意查询语句的权限，可能由于提交用户的不当操作对生产实例造成影响

调整：
- 增加配置项check_max_execution_time，用于配置审核检测的会话执行时间
- 在检测过程中设置该变量
- 忽略获取真实影响行数超时的问题，超时后依然走explain判断

不足和风险：
- 全局设置改变量不太合理，实际应该在获取真实影响行数时设置更友好
- 对于获取真实影响行数执行超时的场景判断和处理，现在直接判断`AffectedRows > 0`不合理（不太会改）

个人的想法，看是否有必要调整和合并

关于max_execution_time参数的版本：https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-8.html