### PR TITLE
update: 优化数据库连接超时时的处理(#306)

### DIFF
--- a/session/inception_result.go
+++ b/session/inception_result.go
@@ -98,6 +98,16 @@ type Record struct {
 	MultiTables map[string]*TableInfo
 }
 
+func (r *Record) appendWarningMessage(msg string) {
+	r.ErrLevel = uint8(Max(int(r.ErrLevel), int(1)))
+
+	r.Buf.WriteString(msg)
+	if !strings.HasSuffix(msg, ".") && !strings.HasSuffix(msg, "!") {
+		r.Buf.WriteString(".")
+	}
+	r.Buf.WriteString("\n")
+}
+
 func (r *Record) appendErrorMessage(msg string) {
 	r.ErrLevel = 2
 

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -7122,6 +7122,18 @@ func (s *session) appendErrorMessage(msg string) {
 	s.myRecord.appendErrorMessage(msg)
 }
 
+func (s *session) appendWarningMessage(msg string) {
+	if s.stage != StageCheck && s.recordSets.MaxLevel == 0 {
+		if s.stage == StageBackup {
+			s.myRecord.Buf.WriteString("Backup: ")
+		} else if s.stage == StageExec {
+			s.myRecord.Buf.WriteString("Execute: ")
+		}
+	}
+	s.myRecord.appendWarningMessage(msg)
+	s.recordSets.MaxLevel = uint8(Max(int(s.recordSets.MaxLevel), int(s.myRecord.ErrLevel)))
+}
+
 func (s *session) appendWarning(number ErrorCode, values ...interface{}) {
 	if s.stage == StageBackup {
 		s.myRecord.Buf.WriteString("Backup: ")


### PR DESCRIPTION
当连接超时时自动重连数据库。

内置限制：仅在超时设置不小于600s(即10分钟)时开启该功能(参数`wait_timeout`)，以免错误重连。

相关问题： #306 
