### PR TITLE
fix: 修复rename table语法一次修改多个表名时，有表名逻辑上不生效的问题 (#307)

### DIFF
--- a/session/session_inception_backup_test.go
+++ b/session/session_inception_backup_test.go
@@ -782,6 +782,14 @@ func (s *testSessionIncBackupSuite) TestRenameTable(c *C) {
 	backup = s.query("t1", row[7].(string))
 	c.Assert(backup, Equals, "ALTER TABLE `test_inc`.`t1` RENAME TO `test_inc`.`t2`;", Commentf("%v", s.rows))
 
+	s.mustRunExec(c, `drop table if exists t1,t2,t1_old;
+	create table t1(id int primary key);
+	create table t2(id int primary key);`)
+	s.mustRunBackup(c, "rename table t1 to t1_old,t2 to t1;")
+	row = s.rows[s.getAffectedRows()-1]
+	backup = s.query("t1", row[7].(string))
+	c.Assert(backup, Equals, "RENAME TABLE `test_inc`.`t1` TO `test_inc`.`t2`,`test_inc`.`t1_old` TO `test_inc`.`t1`;", Commentf("%v", s.rows))
+
 }
 
 func (s *testSessionIncBackupSuite) TestAlterTableCreateIndex(c *C) {


### PR DESCRIPTION
修复当执行类似如下SQL时，除第一个表外，其他表名在审核时会报找不到的错误。
```sql
rename table t1 to t1_old,t2 to t1;
```

关联：#307

