### PR TITLE
fix: 修复dml回滚语句未忽略计算列的问题(#324)

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -7544,6 +7544,13 @@ func (s *session) buildNewColumnToCache(t *TableInfo, field *ast.ColumnDef) *Fie
 			field.Tp.Flag |= mysql.OnUpdateNowFlag
 		case ast.ColumnOptionCollate:
 			c.Collation = op.StrValue
+		case ast.ColumnOptionGenerated:
+			if op.Stored {
+				c.Extra += "STORED"
+			} else {
+				c.Extra += "VIRTUAL"
+			}
+			c.Extra += " GENERATED"
 		}
 	}
 


### PR DESCRIPTION
在修改或删除包含有计算列的行时，未忽略计算列会导致DML回滚语句有误。

关联：#324