### PR TITLE
update: 拆分gh-ost模块，支持binary方式调用gh-ost，以优化gh-ost源码内置带来的问题

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -97,10 +97,15 @@ jobs:
 
       - name: Install pt-online-schema-change
         run: |
-          # sudo wget -O /usr/local/bin/pt-online-schema-change percona.com/get/pt-online-schema-change
           sudo cp ./bin/pt-online-schema-change  /usr/local/bin/pt-online-schema-change
           sudo chmod +x /usr/local/bin/pt-online-schema-change
           sudo apt-get install libdbi-perl libdbd-mysql-perl
+
+      - name: Install gh-ost
+        run: |
+          sudo wget -O gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+          sudo tar -zxvf gh-ost.tar.gz -C /usr/local/bin/
+          sudo chmod +x /usr/local/bin/gh-ost
 
       - name: "Build & Test"
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,30 +5,35 @@ ENV TZ=Asia/Shanghai
 ENV LANG="en_US.UTF-8"
 
 RUN apk add --no-cache \
-    wget \
+    ca-certificates wget \
     make \
     git \
     gcc \
     musl-dev
 
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+RUN wget -q -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+&& wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+&& wget -q -O /glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk \
  && chmod +x /usr/local/bin/dumb-init
 
 COPY bin/goInception /goInception
 # COPY bin/percona-toolkit.tar.gz /tmp/percona-toolkit.tar.gz
 COPY bin/pt-online-schema-change /tmp/pt-online-schema-change
+COPY bin/gh-ost /tmp/gh-ost
 COPY config/config.toml.default /etc/config.toml
-
 
 # Executable image
 FROM alpine
 
+COPY --from=builder /glibc.apk /glibc.apk
+COPY --from=builder /etc/apk/keys/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 COPY --from=builder /goInception /goInception
 COPY --from=builder /etc/config.toml /etc/config.toml
 COPY --from=builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 
 # COPY --from=builder /tmp/percona-toolkit.tar.gz /tmp/percona-toolkit.tar.gz
 COPY --from=builder /tmp/pt-online-schema-change /usr/local/bin/pt-online-schema-change
+COPY --from=builder /tmp/gh-ost /usr/local/bin/gh-ost
 
 WORKDIR /
 
@@ -54,8 +59,9 @@ ENV TZ=Asia/Shanghai
 
 
 RUN set -x \
-  && apk add --no-cache perl perl-dbi perl-dbd-mysql perl-io-socket-ssl perl-term-readkey tzdata \
+  && apk add --no-cache perl perl-dbi perl-dbd-mysql perl-io-socket-ssl perl-term-readkey tzdata /glibc.apk \
   && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-  && chmod +x /usr/local/bin/pt-online-schema-change
+  && chmod +x /usr/local/bin/pt-online-schema-change \
+  && chmod +x /usr/local/bin/gh-ost
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/goInception","--config=/etc/config.toml"]

--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,10 @@ docker:
 	@if [ ! -f bin/pt-online-schema-change ];then \
 		wget -O bin/pt-online-schema-change percona.com/get/pt-online-schema-change; \
 	fi
+	@if [ ! -f bin/gh-ost ];then \
+		wget -O bin/gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz; \
+		tar -zxvf bin/gh-ost.tar.gz -C bin/; \
+	fi
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags '-s -w $(LDFLAGS)' -o bin/goInception tidb-server/main.go
 	v1=$(shell git tag | awk -F'-' '{print $1}' |tail -1) && docker build -t hanchuanchuan/goinception:$${v1} . \
 	&& docker tag hanchuanchuan/goinception:$${v1} hanchuanchuan/goinception:latest

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,7 @@ jobs:
       - run: rm -f go.sum
       # - run: sudo wget -O /usr/local/bin/pt-online-schema-change percona.com/get/pt-online-schema-change
       - run: sudo cp ./bin/pt-online-schema-change  /usr/local/bin/pt-online-schema-change
-      - run: sudo wget -O bin/gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz && tar -zxvf bin/gh-ost.tar.gz -C /usr/local/bin/
+      - run: sudo wget -O gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz && tar -zxvf gh-ost.tar.gz -C /usr/local/bin/
       - run: sudo chmod +x /usr/local/bin/pt-online-schema-change
       - run: sudo chmod +x /usr/local/bin/gh-ost
       - run: sudo chmod +x cmd/explaintest/run-tests.sh

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,9 @@ jobs:
       - run: rm -f go.sum
       # - run: sudo wget -O /usr/local/bin/pt-online-schema-change percona.com/get/pt-online-schema-change
       - run: sudo cp ./bin/pt-online-schema-change  /usr/local/bin/pt-online-schema-change
+      - run: sudo wget -O bin/gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz && tar -zxvf bin/gh-ost.tar.gz -C /usr/local/bin/
       - run: sudo chmod +x /usr/local/bin/pt-online-schema-change
+      - run: sudo chmod +x /usr/local/bin/gh-ost
       - run: sudo chmod +x cmd/explaintest/run-tests.sh
 
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -41,7 +41,8 @@ jobs:
       - run: rm -f go.sum
       # - run: sudo wget -O /usr/local/bin/pt-online-schema-change percona.com/get/pt-online-schema-change
       - run: sudo cp ./bin/pt-online-schema-change  /usr/local/bin/pt-online-schema-change
-      - run: sudo wget -O gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz && tar -zxvf gh-ost.tar.gz -C /usr/local/bin/
+      - run: sudo wget -O gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+      - run: sudo tar -zxvf gh-ost.tar.gz -C /usr/local/bin/
       - run: sudo chmod +x /usr/local/bin/pt-online-schema-change
       - run: sudo chmod +x /usr/local/bin/gh-ost
       - run: sudo chmod +x cmd/explaintest/run-tests.sh

--- a/config/config.go
+++ b/config/config.go
@@ -598,6 +598,9 @@ type Ghost struct {
 	// 告诉gh-ost你正在运行的是一个tungsten-replication拓扑结构。
 	GhostTungsten            bool   `toml:"ghost_tungsten"`
 	GhostReplicationLagQuery string `toml:"ghost_replication_lag_query"`
+
+	// gh-ost所在目录，当设置该参数时，则启用二进制gh-ost
+	GhostBinDir string `toml:"ghost_bin_dir" json:"ghost_bin_dir"`
 }
 
 type IncLevel struct {

--- a/session/osc.go
+++ b/session/osc.go
@@ -205,9 +205,8 @@ func (s *session) mysqlExecuteAlterTableOsc(r *Record) {
 }
 
 func (s *session) mysqlExecuteWithGhost(r *Record) {
-
 	err := os.Setenv("PATH", fmt.Sprintf("%s%s%s",
-		s.osc.OscBinDir, string(os.PathListSeparator), os.Getenv("PATH")))
+		s.ghost.GhostBinDir, string(os.PathListSeparator), os.Getenv("PATH")))
 	if err != nil {
 		log.Error(err)
 		s.appendErrorMessage(err.Error())

--- a/session/osc.go
+++ b/session/osc.go
@@ -201,8 +201,7 @@ func (s *session) mysqlExecuteAlterTableOsc(r *Record) {
 
 	str := buf.String()
 
-	s.execCommand(r, "sh", []string{"-c", str})
-
+	s.execCommand(r, "", "sh", []string{"-c", str})
 }
 
 func (s *session) mysqlExecuteWithGhost(r *Record) {
@@ -347,7 +346,7 @@ func (s *session) mysqlExecuteWithGhost(r *Record) {
 
 	log.Infof("sh: %s", str)
 
-	s.execCommand(r, "sh", []string{"-c", str})
+	s.execCommand(r, socketFile, "sh", []string{"-c", str})
 
 }
 
@@ -770,7 +769,7 @@ func (s *session) mysqlExecuteAlterTableGhost(r *Record) {
 	}
 }
 
-func (s *session) execCommand(r *Record, commandName string, params []string) bool {
+func (s *session) execCommand(r *Record, socketFile string, commandName string, params []string) bool {
 	//函数返回一个*Cmd，用于使用给出的参数执行name指定的程序
 	cmd := exec.Command(commandName, params...)
 
@@ -811,6 +810,8 @@ func (s *session) execCommand(r *Record, commandName string, params []string) bo
 		Percent:    0,
 		RemainTime: "",
 		Info:       "",
+		IsGhost:    socketFile != "",
+		SocketFile: socketFile,
 		PanicAbort: make(chan util.ProcessOperation),
 		RW:         &sync.RWMutex{},
 	}

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -1432,7 +1432,8 @@ func (s *session) executeRemoteStatement(record *Record, isTran bool) {
 		if s.ghost.GhostOn {
 			log.Infof("con:%d use gh-ost: %s",
 				s.sessionVars.ConnectionID, record.Sql)
-			s.mysqlExecuteAlterTableGhost(record)
+			// s.mysqlExecuteAlterTableGhost(record)
+			s.mysqlExecuteWithGhost(record)
 		} else {
 			log.Infof("con:%d use pt-osc: %s",
 				s.sessionVars.ConnectionID, record.Sql)

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -1432,10 +1432,15 @@ func (s *session) executeRemoteStatement(record *Record, isTran bool) {
 
 	if record.useOsc {
 		if s.ghost.GhostOn {
-			log.Infof("con:%d use gh-ost: %s",
-				s.sessionVars.ConnectionID, record.Sql)
-			// s.mysqlExecuteAlterTableGhost(record)
-			s.mysqlExecuteWithGhost(record)
+			if s.ghost.GhostBinDir != "" {
+				log.Infof("con:%d use binary gh-ost: %s",
+					s.sessionVars.ConnectionID, record.Sql)
+				s.mysqlExecuteWithGhost(record)
+			} else {
+				log.Infof("con:%d use gh-ost: %s",
+					s.sessionVars.ConnectionID, record.Sql)
+				s.mysqlExecuteAlterTableGhost(record)
+			}
 		} else {
 			log.Infof("con:%d use pt-osc: %s",
 				s.sessionVars.ConnectionID, record.Sql)

--- a/session/session_inception_exec_test.go
+++ b/session/session_inception_exec_test.go
@@ -989,6 +989,11 @@ func (s *testSessionIncExecSuite) TestAlterTableGhost(c *C) {
 
 	sql = "alter table t1 add column `c5` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";  -- 测试注释"
 	s.testErrorCode(c, sql)
+
+	config.GetGlobalConfig().Ghost.GhostBinDir = "/usr/local/bin"
+
+	sql = "alter table t1 add column `c6` varchar(20) comment \"!@#$%^&*()_+[]{}\\|;:',.<>/?\";  -- 测试注释"
+	s.testErrorCode(c, sql)
 }
 
 // 测试忽略指定的Alter语句

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -90,5 +90,8 @@ type OscProcessInfo struct {
 
 	PanicAbort chan ProcessOperation
 
+	// gh-ost serve-socket-file
+	SocketFile string
+
 	RW *sync.RWMutex
 }


### PR DESCRIPTION
功能开关参数：`ghost_bin_dir`，使用方式和pt-online-schema-change的`osc_bin_dir`参数一样。

在启用gh-ost方式执行ALTER变更时，若配置了`ghost_bin_dir`参数，则以binary方式调用外部的gh-ost，否则仍以默认的内置gh-ost来执行。

关联问题：#305
