### PR TITLE
feature: 添加masking功能-语法树解析功能升级,返回select涉及的对象(库.表.列)

### DIFF
--- a/session/common.go
+++ b/session/common.go
@@ -134,6 +134,8 @@ type SourceOptions struct {
 
 	// 打印语法树功能
 	Print bool
+	// 语法树v2功能，以列方式返回query涉及的字段列表
+	Masking bool
 
 	// DDL/DML分隔功能
 	split bool
@@ -197,6 +199,16 @@ type FieldInfo struct {
 	isGenerated *bool `gorm:"-"`
 
 	Tp *types.FieldType `gorm:"-"`
+}
+
+// MaskingFieldInfo 脱敏功能的字段信息
+type MaskingFieldInfo struct {
+	Index  uint8  `json:"index"`
+	Field  string `json:"field"`
+	Type   string `json:"type"`
+	Table  string `json:"table"`
+	Schema string `json:"schema"`
+	Alias  string `json:"alias"`
 }
 
 func (f *FieldInfo) IsGenerated() bool {

--- a/session/inception_masking_test.go
+++ b/session/inception_masking_test.go
@@ -1,0 +1,100 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hanchuanchuan/goInception/config"
+	"github.com/hanchuanchuan/goInception/util/testkit"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testSessionMaskingSuite{})
+
+func TestMasking(t *testing.T) {
+	TestingT(t)
+}
+
+type testSessionMaskingSuite struct {
+	testCommon
+}
+
+func (s *testSessionMaskingSuite) SetUpSuite(c *C) {
+
+	s.initSetUp(c)
+
+	config.GetGlobalConfig().Inc.Lang = "en-US"
+	config.GetGlobalConfig().Inc.EnableFingerprint = true
+	config.GetGlobalConfig().Inc.SqlSafeUpdates = 0
+
+	if s.tk == nil {
+		s.tk = testkit.NewTestKitWithInit(c, s.store)
+	}
+}
+
+func (s *testSessionMaskingSuite) TearDownSuite(c *C) {
+	s.tearDownSuite(c)
+}
+
+func (s *testSessionMaskingSuite) makeSQL(sql string) *testkit.Result {
+	a := `/*--user=test;--password=test;--host=127.0.0.1;--masking=1;--port=3306;--enable-ignore-warnings;*/
+inception_magic_start;
+use test_inc;
+%s;
+inception_magic_commit;`
+	return s.tk.MustQueryInc(fmt.Sprintf(a, sql))
+}
+
+func (s *testSessionMaskingSuite) TestInsert(c *C) {
+
+	res := s.makeSQL("insert into t1 values(1);")
+	row := res.Rows()[int(s.tk.Se.AffectedRows())-1]
+	c.Assert(row[2], Equals, "2", Commentf("%v", row))
+	c.Assert(row[4], Equals, "not support", Commentf("%v", row))
+
+	res = s.makeSQL("insert into t1 values;")
+
+	if len(res.Rows()) > 0 {
+		row = res.Rows()[int(s.tk.Se.AffectedRows())-1]
+		c.Assert(row[2], Equals, "2", Commentf("%v", row))
+		c.Assert(row[4], Equals, "line 1 column 21 near \"\" ", Commentf("%v", row))
+	} else {
+		c.Assert(len(res.Rows()), Greater, 0, Commentf("%v", res))
+	}
+}
+
+func (s *testSessionMaskingSuite) TestQuery(c *C) {
+
+	s.mustRunExec(c, `drop table if exists t1,t2;
+	create table t1(id int primary key,c1 int);
+	create table t2(id int primary key,c1 int,c2 int);
+	insert into t1 values(1,1),(2,2);`)
+
+	res := s.makeSQL(`select * from t1;`)
+	row := res.Rows()[int(s.tk.Se.AffectedRows())-1]
+	c.Assert(row[2], Equals, "0", Commentf("%v", row))
+	c.Assert(row[3], Equals, `[{"index":0,"field":"id","type":"int(11)","table":"t1","schema":"test_inc","alias":"id"},{"index":1,"field":"c1","type":"int(11)","table":"t1","schema":"test_inc","alias":"c1"}]`, Commentf("%v", row))
+
+	res = s.makeSQL(`select * from t1 union select id,c2 from t2;`)
+	row = res.Rows()[int(s.tk.Se.AffectedRows())-1]
+	c.Assert(row[2], Equals, "0", Commentf("%v", row))
+	c.Assert(row[3], Equals, `[{"index":0,"field":"id","type":"int(11)","table":"t1","schema":"test_inc","alias":"id"},{"index":1,"field":"c1","type":"int(11)","table":"t1","schema":"test_inc","alias":"c1"},{"index":0,"field":"id","type":"int(11)","table":"t2","schema":"test_inc","alias":"id"},{"index":1,"field":"c2","type":"int(11)","table":"t2","schema":"test_inc","alias":"c2"}]`, Commentf("%v", row))
+
+	res = s.makeSQL(`select ifnull(c1,c2) from t1 inner join t2 on t1.id=t2.id`)
+	row = res.Rows()[int(s.tk.Se.AffectedRows())-1]
+	c.Assert(row[2], Equals, "0", Commentf("%v", row))
+	c.Assert(row[3], Equals, `[{"index":0,"field":"c1","type":"int(11)","table":"t1","schema":"test_inc","alias":"ifnull(c1,c2)"},{"index":0,"field":"c2","type":"int(11)","table":"t2","schema":"test_inc","alias":"ifnull(c1,c2)"}]`, Commentf("%v", row))
+}

--- a/session/session.go
+++ b/session/session.go
@@ -260,6 +260,9 @@ type session struct {
 
 	// 是否检查歧义性. 在order by时忽略该检查,其他时候正常开启
 	checkAmbiguous bool
+
+	// masking 语法树解析功能
+	maskingFields []MaskingFieldInfo
 }
 
 func (s *session) getMembufCap() int {

--- a/session/session_masking.go
+++ b/session/session_masking.go
@@ -39,8 +39,8 @@ func (s *session) maskingCommand(ctx context.Context, stmtNode ast.StmtNode,
 		_, _ = p.checkSelectItem(node, 0)
 		fields := p.maskingFields
 		tree, err := json.Marshal(fields)
-		tree1, _ := json.MarshalIndent(fields, "    ", "")
-		log.Errorf("%#v", string(tree1))
+		// tree1, _ := json.MarshalIndent(fields, "    ", "")
+		// log.Errorf("%#v", string(tree1))
 		if err != nil {
 			log.Error(err)
 			s.printSets.Append(2, currentSql, "", err.Error())

--- a/session/session_masking.go
+++ b/session/session_masking.go
@@ -1,0 +1,553 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	json "github.com/CorgiMan/json2"
+	"github.com/hanchuanchuan/goInception/ast"
+	"github.com/hanchuanchuan/goInception/model"
+	"github.com/hanchuanchuan/goInception/util/sqlexec"
+	log "github.com/sirupsen/logrus"
+)
+
+type masking struct {
+	maskingFields []MaskingFieldInfo
+	session       *session
+	colIndex      int
+}
+
+func (s *session) maskingCommand(ctx context.Context, stmtNode ast.StmtNode,
+	currentSql string) ([]sqlexec.RecordSet, error) {
+	log.Debug("maskingCommand")
+
+	s.maskingFields = make([]MaskingFieldInfo, 0)
+	switch node := stmtNode.(type) {
+	case *ast.UseStmt:
+		s.dbName = node.DBName
+	case *ast.UnionStmt, *ast.SelectStmt:
+		p := masking{
+			session:       s,
+			maskingFields: make([]MaskingFieldInfo, 0),
+		}
+		_, _ = p.checkSelectItem(node, 0)
+		fields := p.maskingFields
+		tree, err := json.Marshal(fields)
+		tree1, _ := json.MarshalIndent(fields, "    ", "")
+		log.Errorf("%#v", string(tree1))
+		if err != nil {
+			log.Error(err)
+			s.printSets.Append(2, currentSql, "", err.Error())
+		} else {
+			s.printSets.Append(0, currentSql, string(tree), "")
+		}
+	default:
+		s.printSets.Append(2, currentSql, "", "not support")
+	}
+
+	return nil, nil
+}
+
+func (s *masking) checkSelectItem(node ast.ResultSetNode, level int) (
+	tables []*TableInfo, fields []MaskingFieldInfo) {
+	if node == nil {
+		return
+	}
+
+	switch x := node.(type) {
+	case *ast.UnionStmt:
+		for _, sel := range x.SelectList.Selects {
+			tmpTables, tmpFields := s.checkSubSelectItem(sel, level)
+			if tmpTables != nil {
+				tables = append(tables, tmpTables...)
+			}
+			fields = append(fields, tmpFields...)
+		}
+		return
+	case *ast.SelectStmt:
+		return s.checkSubSelectItem(x, level)
+
+	case *ast.Join:
+		tmpTables, tmpFields := s.checkSelectItem(x.Left, level+1)
+		tables = append(tables, tmpTables...)
+		fields = append(fields, tmpFields...)
+
+		tmpTables, tmpFields = s.checkSelectItem(x.Right, level+1)
+		tables = append(tables, tmpTables...)
+		fields = append(fields, tmpFields...)
+		return
+	case *ast.TableSource:
+		switch tblSource := x.Source.(type) {
+		case *ast.TableName:
+			dbName := tblSource.Schema.O
+			if dbName == "" {
+				dbName = s.session.dbName
+			}
+			t := s.session.getTableFromCache(dbName, tblSource.Name.O, false)
+			if t != nil {
+				if x.AsName.L != "" {
+					t.AsName = x.AsName.O
+					return []*TableInfo{t.copy()}, nil
+				}
+				return []*TableInfo{t}, nil
+			}
+			return
+		case *ast.SelectStmt:
+			return s.checkSubSelectItem(tblSource, level+1)
+
+		case *ast.UnionStmt:
+			return s.checkSelectItem(tblSource, level+1)
+
+		default:
+			return s.checkSelectItem(tblSource, level+1)
+		}
+
+	default:
+		log.Infof("%T", x)
+	}
+	return
+}
+
+func (s *masking) checkSubSelectItem(node *ast.SelectStmt, level int) (tableInfoList []*TableInfo, fields []MaskingFieldInfo) {
+	log.Debug("checkSubSelectItem")
+
+	var tableList []*ast.TableSource
+	if node.From != nil {
+		tableList = extractTableList(node.From.TableRefs, tableList)
+	}
+
+	for _, tblSource := range tableList {
+		switch x := tblSource.Source.(type) {
+		case *ast.TableName:
+			tblName := x
+			dbName := tblName.Schema.O
+			if dbName == "" {
+				dbName = s.session.dbName
+			}
+			t := s.session.getTableFromCache(dbName, tblName.Name.O, false)
+			if t != nil {
+				// if tblSource.AsName.L != "" {
+				// 	t.AsName = tblSource.AsName.O
+				// }
+				// tableInfoList = append(tableInfoList, t)
+
+				if tblSource.AsName.L != "" {
+					t.AsName = tblSource.AsName.O
+					tableInfoList = append(tableInfoList, t.copy())
+				} else {
+					tableInfoList = append(tableInfoList, t)
+				}
+			} else {
+				tableInfoList = append(tableInfoList, &TableInfo{
+					Schema: tblName.Schema.String(),
+					Name:   tblName.Name.String(),
+				})
+			}
+		case *ast.SelectStmt:
+			// 递归审核子查询
+			tmpTables, tmpFields := s.checkSubSelectItem(x, level+1)
+			tableInfoList = append(tableInfoList, tmpTables...)
+			fields = append(fields, tmpFields...)
+
+			cols := s.session.getSubSelectColumns(x)
+			if cols != nil {
+				rows := make([]FieldInfo, len(cols))
+				for i, colName := range cols {
+					rows[i].Field = colName
+				}
+				t := &TableInfo{
+					Schema: "",
+					Name:   tblSource.AsName.String(),
+					Fields: rows,
+				}
+				tableInfoList = append(tableInfoList, t)
+			}
+		default:
+			tmpTables, tmpFields := s.checkSelectItem(x, level+1)
+			tableInfoList = append(tableInfoList, tmpTables...)
+			fields = append(fields, tmpFields...)
+		}
+	}
+
+	if node.Fields != nil {
+		newFields := make([]*ast.SelectField, 0)
+		for colIndex, field := range node.Fields.Fields {
+			s.colIndex = colIndex
+			// if field.WildCard == nil {
+			// 	s.checkItem(field.Expr, tableInfoList)
+			// }
+			var tmpFields []MaskingFieldInfo
+
+			// log.Infof("field.WildCard: %v, %v", field.WildCard, colIndex)
+			if field.WildCard == nil {
+				tmpFields = append(tmpFields, s.checkItem(field.Expr, tableInfoList)...)
+				fields = append(fields, tmpFields...)
+				s.checkSelectField(field, tableInfoList, level, colIndex)
+				newFields = append(newFields, field)
+				continue
+			}
+
+			db := field.WildCard.Schema.L
+			wildTable := field.WildCard.Table.L
+			if wildTable == "" {
+				for _, tblSource := range tableList {
+					tblName, ok := tblSource.Source.(*ast.TableName)
+					if ok {
+						if tblName.Schema.L == "" {
+							tblName.Schema = model.NewCIStr(s.session.dbName)
+						}
+						t := s.session.getTableFromCache(tblName.Schema.O, tblName.Name.O, false)
+						if t != nil {
+							tmpFields = append(tmpFields,
+								Convert(tblName.Schema.O, tblName.Name.O, t.Fields)...)
+							for _index, f := range t.Fields {
+								tableName := tblSource.AsName.String()
+								if tableName == "" {
+									tableName = tblName.Name.O
+								}
+								newField := &ast.SelectField{
+									Expr: &ast.ColumnNameExpr{
+										Name: &ast.ColumnName{
+											Name:  model.NewCIStr(f.Field),
+											Table: model.NewCIStr(tableName),
+										},
+									},
+								}
+								s.checkSelectField(newField, tableInfoList,
+									level, colIndex+_index)
+								newFields = append(newFields, newField)
+							}
+							s.colIndex += len(t.Fields)
+						} else {
+							s.session.appendErrorNo(ER_TABLE_NOT_EXISTED_ERROR,
+								fmt.Sprintf("`%s`.`%s`", tblName.Schema.O, tblName.Name.String()))
+						}
+					} else {
+						cols := s.session.getSubSelectColumns(tblSource.Source)
+						for _index, f := range cols {
+							newField := &ast.SelectField{
+								Expr: &ast.ColumnNameExpr{
+									Name: &ast.ColumnName{
+										Name:  model.NewCIStr(f),
+										Table: model.NewCIStr(tblSource.AsName.String()),
+									},
+								},
+							}
+							s.checkSelectField(newField, tableInfoList,
+								level, colIndex+_index)
+							newFields = append(newFields, newField)
+						}
+						s.colIndex += len(cols)
+					}
+				}
+			} else {
+				for _, tblSource := range tableList {
+					tblName, ok := tblSource.Source.(*ast.TableName)
+					tableName := tblSource.AsName.String()
+					if tableName == "" {
+						tableName = tblName.Name.L
+					} else if ok {
+						tableName = tblName.Name.L
+					}
+
+					if (ok && (db == "" || db == tblName.Schema.L) && wildTable == tableName) || (!ok && wildTable == tableName) {
+						if ok {
+							dbName := tblName.Schema.O
+							if dbName == "" {
+								dbName = s.session.dbName
+							}
+							t := s.session.getTableFromCache(dbName, tblName.Name.O, false)
+							if t != nil {
+								tmpFields = append(tmpFields,
+									Convert(tblName.Schema.O, tblName.Name.O, t.Fields)...)
+								for _index, f := range t.Fields {
+									tableName := tblSource.AsName.String()
+									if tableName == "" {
+										tableName = tblName.Name.O
+									}
+									newField := &ast.SelectField{
+										Expr: &ast.ColumnNameExpr{
+											Name: &ast.ColumnName{
+												Name:  model.NewCIStr(f.Field),
+												Table: model.NewCIStr(tableName),
+											},
+										},
+									}
+									s.checkSelectField(newField, tableInfoList,
+										level, colIndex+_index)
+									newFields = append(newFields, newField)
+								}
+								s.colIndex += len(t.Fields)
+							} else {
+								s.session.appendErrorNo(ER_TABLE_NOT_EXISTED_ERROR,
+									fmt.Sprintf("`%s`.`%s`", tblName.Schema.O, tblName.Name.String()))
+							}
+						} else {
+							cols := s.session.getSubSelectColumns(tblSource.Source)
+							for _index, f := range cols {
+								newField := &ast.SelectField{
+									Expr: &ast.ColumnNameExpr{
+										Name: &ast.ColumnName{
+											Name:  model.NewCIStr(f),
+											Table: model.NewCIStr(field.WildCard.Table.O),
+										},
+									},
+								}
+								s.checkSelectField(newField, tableInfoList,
+									level, colIndex+_index)
+								newFields = append(newFields, newField)
+							}
+							s.colIndex += len(cols)
+						}
+					}
+				}
+			}
+			if tmpFields != nil {
+				fields = append(fields, tmpFields...)
+			}
+		}
+		if len(newFields) > len(node.Fields.Fields) {
+			node.Fields.Fields = newFields
+		}
+	}
+	return tableInfoList, fields
+}
+
+func (s *masking) checkSelectField(field *ast.SelectField,
+	tableInfoList []*TableInfo, level, colIndex int) {
+	if level == 0 {
+		for _, f := range s.checkItem(field.Expr, tableInfoList) {
+			f.Index = uint8(colIndex)
+			if field.AsName.String() != "" {
+				f.Alias = field.AsName.String()
+				s.maskingFields = append(s.maskingFields, f)
+			} else {
+				f.Alias = s.getExprAliasName(field)
+				s.maskingFields = append(s.maskingFields, f)
+			}
+		}
+	}
+}
+
+func (s *masking) checkItem(expr ast.ExprNode, tables []*TableInfo) (fields []MaskingFieldInfo) {
+
+	if expr == nil {
+		return
+	}
+
+	switch e := expr.(type) {
+	case *ast.ColumnNameExpr:
+		f := s.checkFieldItem(e.Name, tables)
+		if f == nil {
+			s.session.appendErrorNo(ER_COLUMN_NOT_EXISTED, e.Name.OrigColName())
+		} else {
+			fields = append(fields, *f)
+		}
+		if e.Refer != nil {
+			fields = append(fields, s.checkItem(e.Refer.Expr, tables)...)
+		}
+
+	case *ast.BinaryOperationExpr:
+		fields = append(fields, s.checkItem(e.L, tables)...)
+		fields = append(fields, s.checkItem(e.R, tables)...)
+
+	case *ast.UnaryOperationExpr:
+		fields = append(fields, s.checkItem(e.V, tables)...)
+
+	case *ast.FuncCallExpr:
+		return s.checkFuncItem(e, tables)
+
+	case *ast.FuncCastExpr:
+		fields = append(fields, s.checkItem(e.Expr, tables)...)
+
+	case *ast.AggregateFuncExpr:
+		return s.checkAggregateFuncItem(e, tables)
+
+	case *ast.PatternInExpr:
+		fields = append(fields, s.checkItem(e.Expr, tables)...)
+		for _, expr := range e.List {
+			fields = append(fields, s.checkItem(expr, tables)...)
+		}
+		if e.Sel != nil {
+			fields = append(fields, s.checkItem(e.Sel, tables)...)
+		}
+	case *ast.PatternLikeExpr:
+		return s.checkItem(e.Expr, tables)
+	case *ast.PatternRegexpExpr:
+		return s.checkItem(e.Expr, tables)
+
+	case *ast.SubqueryExpr:
+		_, fields = s.checkSelectItem(e.Query, 1)
+		return fields
+
+	case *ast.CompareSubqueryExpr:
+		fields = append(fields, s.checkItem(e.L, tables)...)
+		fields = append(fields, s.checkItem(e.R, tables)...)
+
+	case *ast.ExistsSubqueryExpr:
+		_, fields = s.checkSelectItem(e.Sel, 1)
+		return fields
+
+	case *ast.IsNullExpr:
+		return s.checkItem(e.Expr, tables)
+	case *ast.IsTruthExpr:
+		return s.checkItem(e.Expr, tables)
+
+	case *ast.BetweenExpr:
+		fields = append(fields, s.checkItem(e.Expr, tables)...)
+		fields = append(fields, s.checkItem(e.Left, tables)...)
+		fields = append(fields, s.checkItem(e.Right, tables)...)
+
+	case *ast.CaseExpr:
+		fields = append(fields, s.checkItem(e.Value, tables)...)
+		for _, when := range e.WhenClauses {
+			fields = append(fields, s.checkItem(when.Expr, tables)...)
+			fields = append(fields, s.checkItem(when.Result, tables)...)
+		}
+		fields = append(fields, s.checkItem(e.ElseClause, tables)...)
+
+	case *ast.DefaultExpr:
+		// s.checkFieldItem(e.Name, tables)
+		// pass
+
+	case *ast.ParenthesesExpr:
+		fields = append(fields, s.checkItem(e.Expr, tables)...)
+
+	case *ast.RowExpr:
+		for _, expr := range e.Values {
+			fields = append(fields, s.checkItem(expr, tables)...)
+		}
+
+	case *ast.ValuesExpr:
+		fields = append(fields, *s.checkFieldItem(e.Column.Name, tables))
+
+	case *ast.VariableExpr:
+		return s.checkItem(e.Value, tables)
+
+	case *ast.ValueExpr, *ast.ParamMarkerExpr, *ast.PositionExpr:
+		// pass
+
+	default:
+		log.Infof("checkItem: %#v", e)
+	}
+
+	return
+}
+
+// getExprAliasName 获取列别名
+func (s *masking) getExprAliasName(field *ast.SelectField) string {
+	expr := field.Expr
+	if expr == nil {
+		return ""
+	}
+	switch e := expr.(type) {
+	case *ast.ColumnNameExpr:
+		return e.Name.Name.String()
+	case *ast.BinaryOperationExpr, *ast.UnaryOperationExpr, *ast.FuncCallExpr,
+		*ast.FuncCastExpr,
+		*ast.AggregateFuncExpr, *ast.PatternInExpr, *ast.PatternLikeExpr,
+		*ast.PatternRegexpExpr, *ast.SubqueryExpr, *ast.CompareSubqueryExpr,
+		*ast.ExistsSubqueryExpr, *ast.IsNullExpr, *ast.IsTruthExpr,
+		*ast.BetweenExpr, *ast.CaseExpr, *ast.ParenthesesExpr,
+		*ast.RowExpr, *ast.ValuesExpr, *ast.VariableExpr,
+		*ast.ValueExpr, *ast.ParamMarkerExpr, *ast.PositionExpr:
+
+		return field.Text()
+
+	default:
+		log.Infof("getExprAliasName default: %#v", e)
+		return field.Text()
+	}
+}
+
+func (s *masking) checkFieldItem(name *ast.ColumnName, tables []*TableInfo) *MaskingFieldInfo {
+	db := name.Schema.L
+
+	for _, t := range tables {
+		if name.Table.L != "" {
+			var tName string
+			if t.AsName != "" {
+				tName = t.AsName
+			} else {
+				tName = t.Name
+			}
+			if (db == "" || strings.EqualFold(t.Schema, db)) &&
+				(strings.EqualFold(tName, name.Table.L)) {
+				if len(t.Fields) == 0 {
+					return &MaskingFieldInfo{
+						Schema: t.Schema,
+						Table:  t.Name,
+						Field:  name.Name.String(),
+					}
+				}
+				for _, field := range t.Fields {
+					if strings.EqualFold(field.Field, name.Name.L) && !field.IsDeleted {
+						return &MaskingFieldInfo{
+							Schema: t.Schema,
+							Table:  t.Name,
+							Field:  name.Name.String(),
+							Type:   field.Type,
+						}
+					}
+				}
+			}
+		} else {
+			if len(t.Fields) == 0 {
+				return &MaskingFieldInfo{
+					Schema: t.Schema,
+					Table:  t.Name,
+					Field:  name.Name.String(),
+				}
+			}
+			for _, field := range t.Fields {
+				if strings.EqualFold(field.Field, name.Name.L) && !field.IsDeleted {
+					return &MaskingFieldInfo{
+						Schema: t.Schema,
+						Table:  t.Name,
+						Field:  name.Name.String(),
+						Type:   field.Type,
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// checkFuncItem 检查函数的字段
+func (s *masking) checkFuncItem(f *ast.FuncCallExpr, tables []*TableInfo) (fields []MaskingFieldInfo) {
+	for _, arg := range f.Args {
+		fields = append(fields, s.checkItem(arg, tables)...)
+		// if c:=s.checkColumnExpr(arg,tables);c!=nil{
+		// 	f.Args[index] = c
+		// }
+	}
+	return
+}
+
+// checkAggregateFuncItem 检查聚合函数的字段
+func (s *masking) checkAggregateFuncItem(f *ast.AggregateFuncExpr, tables []*TableInfo) (fields []MaskingFieldInfo) {
+	for _, arg := range f.Args {
+		fields = append(fields, s.checkItem(arg, tables)...)
+	}
+	return
+}
+
+func Convert(schema, table string, fs []FieldInfo) []MaskingFieldInfo {
+	maskingFields := make([]MaskingFieldInfo, len(fs))
+	for index, f := range fs {
+		maskingFields[index] = MaskingFieldInfo{
+			Field:  f.Field,
+			Type:   f.Type,
+			Schema: schema,
+			Table:  table,
+		}
+	}
+	return maskingFields
+}


### PR DESCRIPTION
*** 语法树功能升级

返回解析和原语法树查询功能一致(引用自文档[语法树说明](https://hanchuanchuan.github.io/goInception/tree.html))
1. ID：这个用来表示当前语句的一个序列值。
2. STATEMENT：这个列用来存储当前被分析的SQL语句。
3. ERRLEVEL：这个列用来存储当打印遇到问题时，错误的级别，与审核结果集中的ERRLEVEL意义相同。
4. QUERY_TREE：这个列就是对当前语句的分析结果，格式为JSON字符串。
5. ERRMSG：这个列与上面的ERRLEVEL对应，当出错时，这里存储分析过程中所有的错误信息，与审核结果集中的同名列意义相同。

其中,唯一有改动的`QUERY_TREE`返回格式如下:

```sql
select MOD(id,2)as col1,IFNULL(c1,id) from t1; -- 示例SQL
```

```json
[
    {
        "index":0,
        "field":"id",
        "type":"int(11)",
        "table":"t1",
        "schema":"test_inc",
        "alias":"col1"
    },
    {
        "index":1,
        "field":"c1",
        "type":"int(11)",
        "table":"t1",
        "schema":"test_inc",
        "alias":"IFNULL(c1,id)"
    },
    {
        "index":1,
        "field":"id",
        "type":"int(11)",
        "table":"t1",
        "schema":"test_inc",
        "alias":"IFNULL(c1,id)"
    }
]
```
字段说明:
* index: 列索引,标识为第几列,可能重复(如函数引用了多列时)
* field: 原始列名
* type: 列类型,扩展属性,以供自定义使用
* table: 原始表名
* schema: 数据库
* alias: 列别名,该值可能不准确(如未定义列别名或列名重复时)

