### PR TITLE
修复TiDB check结果affected_rows返回0的问题

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -6475,8 +6475,8 @@ func (s *session) getExplainInfo(sql string, sqlId string) {
 							row.Rows = int(f)
 						}
 					} else if row.EstRows != "" {
-						if v, err := strconv.Atoi(row.EstRows); err == nil {
-							row.Rows = v
+						if v, err := strconv.ParseFloat(row.EstRows, 64); err == nil {
+							row.Rows = int(v)
 						}
 					}
 				}
@@ -6490,8 +6490,8 @@ func (s *session) getExplainInfo(sql string, sqlId string) {
 						row.Rows = int(f)
 					}
 				} else if row.EstRows != "" {
-					if v, err := strconv.Atoi(row.EstRows); err == nil {
-						row.Rows = v
+					if v, err := strconv.ParseFloat(row.EstRows, 64); err == nil {
+						row.Rows = int(v)
 					}
 				}
 			}


### PR DESCRIPTION
#364 问题：TiDB check 时返回结果为 0。


TiDB 不同版本explain 差异，是否考虑使用`strconv.ParseFloat` 而不是 `strconv.Atoi`

1、3.0.19 explain 返回的 count

```
MySQL [xxx]> select version();
+---------------------+
| version()           |
+---------------------+
| 5.7.25-TiDB-v3.0.19 |
+---------------------+
1 row in set (0.00 sec)

MySQL [xxx]> explain delete from temp_vip_xxx where id = 1;
+-------------------+-------+------+---------------------------------+
| id                | count | task | operator info                   |
+-------------------+-------+------+---------------------------------+
| Delete_2          | N/A   | root | N/A                             |
| └─Point_Get_1     | 1.00  | root | table:temp_vip_xxx, handle:1 |
+-------------------+-------+------+---------------------------------+
2 rows in set (0.00 sec)
```

2、4.0.18 explain 返回的 estRows 值是 5.00

```
mysql> select version();
+--------------------+
| version()          |
+--------------------+
| 5.7.25-TiDB-v4.0.8 |
+--------------------+
1 row in set (0.01 sec)

mysql> explain update q8 set user_name = 'test2';
+-------------------------+---------+-----------+---------------+--------------------------------+
| id                      | estRows | task      | access object | operator info                  |
+-------------------------+---------+-----------+---------------+--------------------------------+
| Update_3                | N/A     | root      |               | N/A                            |
| └─TableReader_6         | 5.00    | root      |               | data:TableFullScan_5           |
|   └─TableFullScan_5     | 5.00    | cop[tikv] | table:q8      | keep order:false, stats:pseudo |
+-------------------------+---------+-----------+---------------+--------------------------------+
3 rows in set (0.00 sec)

```

3、5.0.3 explain 返回的 estRows

```
MySQL [tpch_100]> select version();
+--------------------+
| version()          |
+--------------------+
| 5.7.25-TiDB-v5.0.3 |
+--------------------+
1 row in set (0.00 sec)

MySQL [tpch_100]> explain delete from customer limit 5;
+------------------------------+---------+-----------+----------------+--------------------------------+
| id                           | estRows | task      | access object  | operator info                  |
+------------------------------+---------+-----------+----------------+--------------------------------+
| Delete_4                     | N/A     | root      |                | N/A                            |
| └─Limit_8                    | 5.00    | root      |                | offset:0, count:5              |
|   └─TableReader_13           | 5.00    | root      |                | data:Limit_12                  |
|     └─Limit_12               | 5.00    | cop[tikv] |                | offset:0, count:5              |
|       └─TableFullScan_11     | 5.00    | cop[tikv] | table:customer | keep order:false, stats:pseudo |
+------------------------------+---------+-----------+----------------+--------------------------------+
5 rows in set (0.00 sec)
```