### PR TITLE
新增 check_identifier_lower 参数，用于打开表名、列名、索引名小写需求

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -256,6 +256,7 @@ type Inc struct {
 	CheckFloatDouble bool `toml:"check_float_double" json:"check_float_double"`
 
 	CheckIdentifierUpper bool `toml:"check_identifier_upper" json:"check_identifier_upper"`
+	CheckIdentifierLower bool `toml:"check_identifier_lower" json:"check_identifier_lower"`
 
 	// 连接服务器的默认字符集,默认值为utf8mb4
 	DefaultCharset      string `toml:"default_charset" json:"default_charset"`
@@ -753,6 +754,7 @@ var defaultConf = Config{
 		EnableTimeStampType:   true,
 		CheckFloatDouble:      false,
 		CheckIdentifierUpper:  false,
+		CheckIdentifierLower:  false,
 		SqlSafeUpdates:        -1,
 		LockWaitTimeout:       -1,
 		SupportCharset:        "utf8,utf8mb4",

--- a/config/config.toml.default
+++ b/config/config.toml.default
@@ -60,6 +60,8 @@ check_column_comment = false
 
 check_float_double = false
 check_identifier_upper = false
+check_identifier_lower = false
+
 
 # 审核列类型变更
 check_column_type_change = true

--- a/session/errors.go
+++ b/session/errors.go
@@ -201,6 +201,7 @@ const (
 	ER_TOO_MUCH_AUTO_DATETIME_COLS
 	ErrFloatDoubleToDecimal
 	ErrIdentifierUpper
+	ErrIdentifierLower
 	ErrWrongAndExpr
 	ErrCannotAddForeign
 	ErrWrongFkDefWithMatch
@@ -383,6 +384,7 @@ var ErrorsDefault = map[ErrorCode]string{
 	ER_TOO_MUCH_AUTO_DATETIME_COLS: "Incorrect table definition; there can be only one DATETIME column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause",
 	ErrFloatDoubleToDecimal:        "Set column '%s' to DECIMAL type.",
 	ErrIdentifierUpper:             "Identifier '%s' must be capitalized.",
+	ErrIdentifierLower:             "Identifier '%s' must be lowercase.",
 	ErrWrongAndExpr:                "May be the wrong syntax! Separate multiple fields with commas.",
 	ErrCannotAddForeign:            "Cannot add foreign key constraint",
 	ErrWrongFkDefWithMatch:         "Incorrect foreign key definition for '%-.192s': Key reference and table reference don't match",
@@ -560,6 +562,7 @@ var ErrorsChinese = map[ErrorCode]string{
 	ER_TOO_MUCH_AUTO_DATETIME_COLS:         "表定义不正确,只能有一个 datetime 字段,在 DEFAULT 或 ON UPDATE指定CURRENT_TIMESTAMP.",
 	ErrFloatDoubleToDecimal:                "列 '%s' 建议设置为 decimal 类型.",
 	ErrIdentifierUpper:                     "标识符 '%s' 必须大写.",
+	ErrIdentifierLower:                     "标识符 '%s' 必须小写.",
 	ErrWrongAndExpr:                        "可能是错误语法!更新多个字段时请使用逗号分隔.",
 	ErrJoinNoOnCondition:                   "join语句请指定on子句.",
 	ErrImplicitTypeConversion:              "不允许隐式类型转换(列'%s.%s',类型'%s').",
@@ -1060,6 +1063,8 @@ func (e ErrorCode) String() string {
 		return "er_float_double_to_decimal"
 	case ErrIdentifierUpper:
 		return "er_identifier_upper"
+	case ErrIdentifierLower:
+		return "er_identifier_lower"
 	case ErrWrongAndExpr:
 		return "er_wrong_and_expr"
 	case ErrJoinNoOnCondition:

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4196,6 +4196,10 @@ func (s *session) checkIndexAttr(tp ast.ConstraintType, name string,
 			s.appendErrorNo(ErrIdentifierUpper, name)
 		}
 
+		if name != strings.ToLower(name) {
+			s.appendErrorNo(ErrIdentifierLower, name)
+		}
+
 		if isIncorrectName(name) {
 			s.appendErrorNo(ER_WRONG_NAME_FOR_INDEX, name, table.Name)
 		} else {
@@ -7363,6 +7367,10 @@ func (s *session) checkKeyWords(name string) {
 		s.appendErrorNo(ErrIdentifierUpper, name)
 	}
 
+	if name != strings.ToLower(name) {
+		s.appendErrorNo(ErrIdentifierLower, name)
+	}
+
 	if !regIdentified.MatchString(name) {
 		s.appendErrorNo(ER_INVALID_IDENT, name)
 	} else if _, ok := Keywords[strings.ToUpper(name)]; ok {
@@ -7490,6 +7498,8 @@ func (s *session) checkInceptionVariables(number ErrorCode) bool {
 		return s.inc.CheckDatetimeCount
 	case ErrIdentifierUpper:
 		return s.inc.CheckIdentifierUpper
+	case ErrIdentifierLower:
+		return s.inc.CheckIdentifierLower
 	case ErCantChangeColumn:
 		return !s.inc.EnableChangeColumn
 	}

--- a/session/session_inception_test.go
+++ b/session/session_inception_test.go
@@ -2907,6 +2907,16 @@ func (s *testSessionIncSuite) TestIdentifierUpper(c *C) {
 	config.GetGlobalConfig().Inc.CheckIdentifierUpper = false
 }
 
+func (s *testSessionIncSuite) TestIdentifierLower(c *C) {
+	config.GetGlobalConfig().Inc.CheckIdentifierLower = true
+	sql := `drop table if exists hello;create table hello(id int,c1 float, c2 double,key idx_c1(c1),unique index uniq_a(c2));`
+	s.testErrorCode(c, sql,
+		session.NewErr(session.ErrIdentifierLower, "uniq_a"),
+	)
+
+	config.GetGlobalConfig().Inc.CheckIdentifierLower = false
+}
+
 func (s *testSessionIncSuite) TestMaxKeys(c *C) {
 	//er_too_many_keys
 	config.GetGlobalConfig().Inc.MaxKeys = 2


### PR DESCRIPTION
新增 check_identifier_lower 参数，用于打开表名、列名、索引名小写需求
参考thinkdb commented on 23 Jul 2019