### PR TITLE
fix minor unreachable code caused by log.Fatal

### DIFF
--- a/cmd/benchdb/main.go
+++ b/cmd/benchdb/main.go
@@ -259,8 +259,7 @@ func (ut *benchDB) createTable() {
 	res, _ := ut.mustExec(createSQL)
 	for _, row := range res {
 		if row[2] == "2" {
-			log.Fatal(res)
-			log.Fatal(row)
+			log.Fatal(res, row)
 		}
 	}
 
@@ -345,8 +344,7 @@ func (ut *benchDB) insertRows(spec string) {
 		res, _ := ut.mustExec(bufSQL.String())
 		for _, row := range res {
 			if row[2] == "2" {
-				log.Fatal(res)
-				log.Fatal(row)
+				log.Fatal(res, row)
 			}
 		}
 	})
@@ -369,8 +367,7 @@ func (ut *benchDB) updateRandomRows(spec string) {
 		res, _ := ut.mustExec(bufSQL.String())
 		for _, row := range res {
 			if row[2] == "2" {
-				log.Fatal(res)
-				log.Fatal(row)
+				log.Fatal(res, row)
 			}
 		}
 	})
@@ -385,8 +382,7 @@ func (ut *benchDB) updateRangeRows(spec string) {
 		res, _ := ut.mustExec(bufSQL.String())
 		for _, row := range res {
 			if row[2] == "2" {
-				log.Fatal(res)
-				log.Fatal(row)
+				log.Fatal(res, row)
 			}
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

see https://go.dev/play/p/9LyttbdJpv7 for example:
```go
package main

import "log"

func main() {
	log.Fatalf("this line will print and exit")
	log.Fatalf("this line can't print")
}

/* output:
2009/11/10 23:00:00 this line will print and exit

Program exited.
*/
```