### PR TITLE
primary key 不会为null 这里可以排除primay

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4244,6 +4244,9 @@ func (s *session) mysqlCheckField(t *TableInfo, field *ast.ColumnDef, alterTable
 	// 	s.appendErrorNo(ErrJsonTypeSupport, field.Name.Name)
 	// }
 	if !notNullFlag && !hasGenerated {
+		if isPrimary {
+			return
+		}
 		s.appendErrorNo(ER_NOT_ALLOWED_NULLABLE, field.Name.Name, tableName)
 	}
 


### PR DESCRIPTION
在goInception使用过程中,主键不会为null  ，这里可以不用设置为not null 