### PR TITLE
add: cofiguration support environment variables

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -301,6 +301,25 @@ func overrideConfig() {
 	if actualFlags[nmProxyProtocolHeaderTimeout] {
 		cfg.ProxyProtocol.HeaderTimeout = *proxyProtocolHeaderTimeout
 	}
+
+	// cofiguration support environment variables
+	if backupHost := os.Getenv("backup-host"); backupHost != "" {
+		cfg.Inc.BackupHost = backupHost
+	}
+	if backupPort := os.Getenv("backup-port"); backupPort != "" {
+		portUint, err := strconv.ParseUint(backupPort, 10, 16)
+		if err != nil {
+			log.Errorf("backup port should be between 0 and 65535.")
+			os.Exit(-1)
+		}
+		cfg.Inc.BackupPort = uint(portUint)
+	}
+	if backupUser := os.Getenv("backup-user"); backupUser != "" {
+		cfg.Inc.BackupUser = backupUser
+	}
+	if backupPassword := os.Getenv("backup-password"); backupPassword != "" {
+		cfg.Inc.BackupPassword = backupPassword
+	}
 }
 
 func validateConfig() {


### PR DESCRIPTION
这是一种案例，主要参数还是从配置文件读取，少量配置例如bakcup_host等相关信息从env读取后和配置文件合并；方便k8s大量快速部署给客户，希望可以抛砖引玉。