### PR TITLE
fix: cofiguration support environment variables

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -303,10 +303,10 @@ func overrideConfig() {
 	}
 
 	// cofiguration support environment variables
-	if backupHost := os.Getenv("backup-host"); backupHost != "" {
+	if backupHost := os.Getenv("BACKUP_HOST"); backupHost != "" {
 		cfg.Inc.BackupHost = backupHost
 	}
-	if backupPort := os.Getenv("backup-port"); backupPort != "" {
+	if backupPort := os.Getenv("BACKUP_PORT"); backupPort != "" {
 		portUint, err := strconv.ParseUint(backupPort, 10, 16)
 		if err != nil {
 			log.Errorf("backup port should be between 0 and 65535.")
@@ -314,10 +314,10 @@ func overrideConfig() {
 		}
 		cfg.Inc.BackupPort = uint(portUint)
 	}
-	if backupUser := os.Getenv("backup-user"); backupUser != "" {
+	if backupUser := os.Getenv("BACKUP_USER"); backupUser != "" {
 		cfg.Inc.BackupUser = backupUser
 	}
-	if backupPassword := os.Getenv("backup-password"); backupPassword != "" {
+	if backupPassword := os.Getenv("BACKUP_PASSWORD"); backupPassword != "" {
 		cfg.Inc.BackupPassword = backupPassword
 	}
 }


### PR DESCRIPTION
这是一种案例，主要参数还是从配置文件读取，少量配置例如bakcup_host等相关信息从env读取后和配置文件合并；方便k8s大量快速部署给客户，希望可以抛砖引玉。



本次pr，修正上次提交变量名不规范的行为；参数命名为全大写加下划线格式, 如BACKUP_HOST等.
https://github.com/hanchuanchuan/goInception/pull/503
