### PR TITLE
[oceanbase] support affected rows in query explain

### DIFF
--- a/session/common.go
+++ b/session/common.go
@@ -7,6 +7,7 @@ package session
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"strconv"
@@ -179,6 +180,33 @@ type ExplainInfo struct {
 	Count string `gorm:"Column:count"`
 	// TiDB (v4.0及之后)的Explain预估行数存储在Count中
 	EstRows string `gorm:"Column:estRows"`
+}
+
+// OceanBaseQueryPlan OceanBase 执行计划信息
+type OceanBaseQueryPlan struct {
+	QueryPlan string `gorm:"Column:Query Plan"`
+}
+
+// OceanBaseExplainInfo OceanBase 执行计划标准格式
+type OceanBaseExplainInfo struct {
+	ID       int         `json:"ID"`
+	Operator string      `json:"OPERATOR"`
+	Name     string      `json:"NAME"`
+	EstRows  int64       `json:"EST.ROWS"`
+	Cost     int         `json:"COST"`
+	OutPut   interface{} `json:"output"`
+}
+
+// Unmarshal 将数据转化为 OceanBaseExplainInfo
+func (info *OceanBaseExplainInfo) Unmarshal(data interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if b != nil {
+		return json.Unmarshal(b, &info)
+	}
+	return nil
 }
 
 // FieldInfo 字段信息

--- a/session/const.go
+++ b/session/const.go
@@ -26,6 +26,7 @@ const (
 	DBTypeMysql = iota
 	DBTypeMariaDB
 	DBTypeTiDB
+	DBTypeOceanBase
 )
 
 // 审核阶段

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -1687,7 +1687,7 @@ func (s *session) mysqlServerVersion() {
 	var name, value string
 	// sql := "select @@version;"
 	sql := `show variables where Variable_name in
-	('innodb_large_prefix','version','sql_mode','lower_case_table_names','wsrep_on',
+	('innodb_large_prefix','version','version_comment','sql_mode','lower_case_table_names','wsrep_on',
 	'explicit_defaults_for_timestamp','enforce_gtid_consistency','gtid_mode',
 	'character_set_database');`
 
@@ -1714,6 +1714,8 @@ func (s *session) mysqlServerVersion() {
 					s.dbType = DBTypeMariaDB
 				} else if strings.Contains(strings.ToLower(value), "tidb") {
 					s.dbType = DBTypeTiDB
+				} else if strings.Contains(strings.ToLower(value), "oceanbase") {
+					s.dbType = DBTypeOceanBase
 				} else {
 					s.dbType = DBTypeMysql
 				}
@@ -1731,6 +1733,10 @@ func (s *session) mysqlServerVersion() {
 					s.appendErrorMsg(fmt.Sprintf("无法解析版本号:%s", value))
 				}
 				log.Debug("db version: ", s.dbVersion)
+			case "version_comment":
+				if strings.Contains(strings.ToLower(value), "oceanbase") {
+					s.dbType = DBTypeOceanBase
+				}
 			case "innodb_large_prefix":
 				emptyInnodbLargePrefix = false
 				s.innodbLargePrefix = (value == "ON" || value == "1")


### PR DESCRIPTION
Support OceanBase query plan format `OceanBaseExplainInfo` in `getExplainInfo` method.

The original output of explain statement is not in standard table format, for example:
```
mysql> EXPLAIN delete from user where id = 1;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Query Plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| ===================================
|ID|OPERATOR  |NAME|EST. ROWS|COST|
-----------------------------------
|0 |DELETE    |    |1        |53  |
|1 | TABLE GET|user|1        |52  |
===================================

Outputs & filters: 
-------------------------------------
  0 - output(nil), filter(nil), params([{user: (user.id, user.name, user.age)}])
  1 - output([user.id], [user.name], [user.age]), filter(nil), 
      access([user.id], [user.name], [user.age]), partitions(p0)
 |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.02 sec)
```

So I choose to use json format here.

```
mysql> EXPLAIN FORMAT=JSON delete from user where id = 1;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Query Plan                                                                                                                                                                                                                                                                                            |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| {
  "ID":1,
  "OPERATOR":"DELETE",
  "NAME":"DELETE",
  "EST.ROWS":1,
  "COST":53,
  "output":"use",
  "CHILD_1": {
    "ID":0,
    "OPERATOR":"TABLE GET",
    "NAME":"TABLE GET",
    "EST.ROWS":1,
    "COST":52,
    "output": [
      "user.id",
      "user.name",
      "user.age"
    ]
  }
} |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.02 sec)
```