### PR TITLE
add ghost_throttle_control_replicas_query

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -601,12 +601,13 @@ type Ghost struct {
 	// 	列出所有需要被检查主从复制延迟的从库。
 	// e.g:
 	// -throttle-control-replica=192.16.12.22:3306,192.16.12.23:3307,192.16.13.12:3308
-	GhostThrottleControlReplicas    string `toml:"ghost_throttle_control_replicas"`
-	GhostThrottleHTTP               string `toml:"ghost_throttle_http"`
-	GhostTimestampOldTable          bool   `toml:"ghost_timestamp_old_table"`
-	GhostThrottleQuery              string `toml:"ghost_throttle_query"`
-	GhostThrottleFlagFile           string `toml:"ghost_throttle_flag_file"`
-	GhostThrottleAdditionalFlagFile string `toml:"ghost_throttle_additional_flag_file"`
+	GhostThrottleControlReplicas      string `toml:"ghost_throttle_control_replicas"`
+	GhostThrottleControlReplicasQuery string `toml:"ghost_throttle_control_replicas_query"`
+	GhostThrottleHTTP                 string `toml:"ghost_throttle_http"`
+	GhostTimestampOldTable            bool   `toml:"ghost_timestamp_old_table"`
+	GhostThrottleQuery                string `toml:"ghost_throttle_query"`
+	GhostThrottleFlagFile             string `toml:"ghost_throttle_flag_file"`
+	GhostThrottleAdditionalFlagFile   string `toml:"ghost_throttle_additional_flag_file"`
 
 	// 告诉gh-ost你正在运行的是一个tungsten-replication拓扑结构。
 	GhostTungsten            bool   `toml:"ghost_tungsten"`

--- a/session/osc.go
+++ b/session/osc.go
@@ -265,7 +265,9 @@ func (s *session) mysqlExecuteWithGhost(r *Record) {
 	} else {
 		masterHost = s.ghost.GhostAssumeMasterHost
 	}
-
+	if s.ghost.GhostThrottleControlReplicasQuery != "" && s.ghost.GhostThrottleControlReplicas == "" {
+		s.ghost.GhostThrottleControlReplicas = s.fetchSlaveHosts(s.ghost.GhostThrottleControlReplicasQuery)
+	}
 	buf.WriteString(fmt.Sprintf(" --assume-master-host=%s", masterHost))
 	buf.WriteString(fmt.Sprintf(" --exact-rowcount=%t", s.ghost.GhostExactRowcount))
 	buf.WriteString(fmt.Sprintf(" --concurrent-rowcount=%t", s.ghost.GhostConcurrentRowcount))
@@ -487,7 +489,12 @@ func (s *session) mysqlExecuteAlterTableGhost(r *Record) {
 	// maxLagMillis := flag.Int64("max-lag-millis", 1500, "replication lag at which to throttle operation")
 	replicationLagQuery := s.ghost.GhostReplicationLagQuery
 	// replicationLagQuery := flag.String("replication-lag-query", "", "Deprecated. gh-ost uses an internal, subsecond resolution query")
-	throttleControlReplicas := s.ghost.GhostThrottleControlReplicas
+	var throttleControlReplicas string
+	if s.ghost.GhostThrottleControlReplicasQuery != "" && s.ghost.GhostThrottleControlReplicas == "" {
+		throttleControlReplicas = s.fetchSlaveHosts(s.ghost.GhostThrottleControlReplicasQuery)
+	} else {
+		throttleControlReplicas = s.ghost.GhostThrottleControlReplicas
+	}
 	// throttleControlReplicas := flag.String("throttle-control-replicas", "", "List of replicas on which to check for lag; comma delimited. Example: myhost1.com:3306,myhost2.com,myhost3.com:3307")
 	throttleQuery := s.ghost.GhostThrottleQuery
 	// throttleQuery := flag.String("throttle-query", "", "when given, issued (every second) to check if operation should throttle. Expecting to return zero for no-throttle, >0 for throttle. Query is issued on the migrated server. Make sure this query is lightweight")

--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -1809,6 +1809,38 @@ func (s *session) mysqlServerVersion() {
 
 }
 
+func (s *session) fetchSlaveHosts(sql string) string {
+	fmt.Println("fetchSlaveHosts")
+	var hosts []string
+	rows, err := s.raw(sql)
+	if rows == nil {
+		rows.Close()
+		return ""
+	} else {
+		for rows.Next() {
+			var host string
+			rows.Scan(&host)
+			fmt.Println("slave")
+			fmt.Println(host)
+			hosts = append(hosts, strings.Split(host, ":")[0])
+		}
+	}
+
+	if err != nil {
+		// log.Error(err, s.threadID)
+		log.Errorf("con:%d thread id:%d %v", s.sessionVars.ConnectionID, s.threadID, err)
+		if myErr, ok := err.(*mysqlDriver.MySQLError); ok {
+			s.appendErrorMsg(myErr.Message)
+		} else {
+			s.appendErrorMsg(err.Error())
+		}
+	}
+
+	result := strings.Join(hosts, ",")
+	fmt.Println(result)
+	return result
+}
+
 func (s *session) fetchThreadID() uint32 {
 
 	if s.threadID > 0 {


### PR DESCRIPTION
Archery 目前没有支持主从关系，云服务一般有固定的帐号建立主从，且端口都为3306 ，通过此查询查到相应的从库，实现gh-ost throttle_control_replicas 参数关联到相应的从库实例
`ghost_throttle_control_replicas_query = "SELECT host from information_schema.processlist where user = 'rsandbox';"
`