### PR TITLE
增加在SQL审核阶段自动识别并合并相同表的alter table语句的功能

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -221,6 +221,7 @@ type Binlog struct {
 
 // Inc is the inception section of the config.
 type Inc struct {
+	AlterAutoMerge bool   `toml:"alter_auto_merge" json:"alter_auto_merge"`
 	BackupHost     string `toml:"backup_host" json:"backup_host"` // 远程备份库信息
 	BackupPassword string `toml:"backup_password" json:"backup_password"`
 	BackupPort     uint   `toml:"backup_port" json:"backup_port"`

--- a/session/common.go
+++ b/session/common.go
@@ -159,6 +159,9 @@ type SourceOptions struct {
 
 	// // 扩展参数,支持一次性会话设置
 	// extendParams string
+
+	// jwx added 查看提交的SQL中是否有一些可以合并成一条
+	checkMerge bool
 }
 
 // ExplainInfo 执行计划信息

--- a/session/common.go
+++ b/session/common.go
@@ -159,9 +159,6 @@ type SourceOptions struct {
 
 	// // 扩展参数,支持一次性会话设置
 	// extendParams string
-
-	// jwx added 查看提交的SQL中是否有一些可以合并成一条
-	checkMerge bool
 }
 
 // ExplainInfo 执行计划信息

--- a/session/inception_result.go
+++ b/session/inception_result.go
@@ -297,7 +297,7 @@ func NewRecordSets() *MyRecordSets {
 		fieldCount: 0,
 	}
 
-	rc.fields = make([]*ast.ResultField, 12)
+	rc.fields = make([]*ast.ResultField, 13)
 
 	// 序号
 	rc.CreateFiled("order_id", mysql.TypeLong)
@@ -321,6 +321,8 @@ func NewRecordSets() *MyRecordSets {
 	rc.CreateFiled("sqlsha1", mysql.TypeString)
 	// 备份用时
 	rc.CreateFiled("backup_time", mysql.TypeString)
+	// SQL语句类型(select, alter, create index .....)
+	rc.CreateFiled("type", mysql.TypeString)
 
 	t.rc = rc
 	return t
@@ -392,6 +394,15 @@ func (s *MyRecordSets) setFields(r *Record) {
 		row[11].SetString("0")
 	} else {
 		row[11].SetString(r.BackupCostTime)
+	}
+
+	_, isAlterTable := r.Type.(*ast.AlterTableStmt)
+	_, isCreateIndex := r.Type.(*ast.CreateIndexStmt)
+	_, isDropIndex := r.Type.(*ast.DropIndexStmt)
+	if isAlterTable || isCreateIndex || isDropIndex {
+		row[12].SetString("alterTable")
+	} else {
+		row[12].SetNull()
 	}
 
 	s.rc.data[s.rc.count] = row

--- a/session/session.go
+++ b/session/session.go
@@ -138,7 +138,6 @@ func (h *StmtHistory) Count() int {
 // jwx added
 type alterTableInfo struct {
 	Name          string
-	alterCount    int
 	alterStmtList []ast.AlterTableStmt
 	mergedSql     string
 }

--- a/session/session.go
+++ b/session/session.go
@@ -137,9 +137,10 @@ func (h *StmtHistory) Count() int {
 
 // jwx added
 type alterTableInfo struct {
-	Name          string
-	alterStmtList []ast.AlterTableStmt
-	mergedSql     string
+	Name              string
+	alterStmtList     []ast.AlterTableStmt
+	mergedSql         string
+	recordSetsPosList []int //  记录当前语句在s.recordSets里的位置，用于修改needMerge字段
 }
 
 type session struct {

--- a/session/session.go
+++ b/session/session.go
@@ -135,7 +135,19 @@ func (h *StmtHistory) Count() int {
 	return len(h.history)
 }
 
+// jwx added
+type alterTableInfo struct {
+	Name          string
+	alterCount    int
+	alterStmtList []ast.AlterTableStmt
+	mergedSql     string
+}
+
 type session struct {
+
+	//jwx added
+	alterTableInfoList []alterTableInfo
+
 	// processInfo is used by ShowProcess(), and should be modified atomically.
 	processInfo atomic.Value
 	txn         TxnState

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -238,7 +238,8 @@ func RegisterStore(name string, driver kv.Driver) error {
 // session.Open() but with the dbname cut off.
 // Examples:
 //    goleveldb://relative/path
-//    boltdb:///absolute/path
+
+//	boltdb:///absolute/path
 //
 // The engine should be registered before creating storage.
 func NewStore(path string) (kv.Storage, error) {


### PR DESCRIPTION
新增 check-merge参数，设置其为1后开启自动合并alter table语句功能（现在仅有命令行参数，后续将添加配置文件参数并将参数名修改为 alter-auto-merge）。在添加了check-merge参数后，goInc会检查用户提交的SQL，并将其中涉及相同表的alter table，create index，drop index语句统一合并为 alter table语句，然后返回SQL检查结果以及合并后新生成的SQL。

goInc校验的返回值增加了一个字段，显示对应的SQL是否为 (alter table|create index|drop index)， 如果是的话，就会显示'alterTable'字样。对于合并后新生成的SQL，ErrorMessage字段显示"Merged"。以上两个字段可用于区分是原有SQL还是合并后的SQL

新增alterTableInfo结构体，记录每一个表被修改的信息，包括表名，所有alter语句的语法树，以及合并后的新SQL

在checkAlterTable方法中写入alterTableInfo，在提交阶段进行SQL的合并工作，通过合并语法树然后生成新的SQL

对于create index和drop index语句，使用convertCreateIndexToAddConstrain和convertDropIndexToDropIndex方法（已修改成convertCreateIndexToAlterTable和convertDropIndexToAlerTable）将其转换为alter table语句，然后进行合并。



