### PR TITLE
修复审核MySQL8.0更改列类型时报数组越界的错误问题

### DIFF
--- a/session/session_inception.go
+++ b/session/session_inception.go
@@ -4315,7 +4315,16 @@ func (s *session) checkModifyColumn(t *TableInfo, c *ast.AlterTableSpec) {
 			case mysql.TypeDecimal, mysql.TypeNewDecimal,
 				mysql.TypeVarchar,
 				mysql.TypeVarString:
-				str := string([]byte(foundField.Type)[:7])
+				/* 
+				这里如果foundField.Type的长度不足7位，直接取[:7],会导致数据越界
+				所以如果foundField.Type长度小于7位，以实际长度进行截取，如果大于等于7位，就按照7位进行截取 
+				*/
+				length := 7
+				legnthOfFoundFieldType := len(foundField.Type)
+				if legnthOfFoundFieldType < length {
+					length = legnthOfFoundFieldType
+				}
+				str := string([]byte(foundField.Type)[:length])
 				// 类型不一致
 				if !strings.Contains(fieldType, str) {
 					s.appendErrorNo(ER_CHANGE_COLUMN_TYPE,


### PR DESCRIPTION
goInception版本：goInception-linux-v1.3.0-94-g2f06c61b95.tar.gz
mysql版本：8.0.20
mysql表结构：create table t1 (id bigint unsigned not null primary key auto_increment, c1 int not null default '0');
alter语句：alter table t1 change column `c1` `c1` varchar(256) not null default '';
使用goInception审核这个alter语句时报：“slice bounds out of range [:7) with capacity 3”错误，原因是同一个建表语句，mysql5.7为int(11),mysql8.0为int
mysql8.0.20
![image](https://github.com/user-attachments/assets/35de3e53-edda-4402-8ce3-efc129331246)
mysql5.7.44
![image](https://github.com/user-attachments/assets/1f70bc06-528c-4860-a153-2d0988688d29)
所以在截取时对foundField.Type做判断，如果foundField.Type长度小于7位，以实际长度进行截取，如果大于等于7位，就按照7位进行截取 
